### PR TITLE
[#3] 회원가입 아이디 중복체크 기능 추가

### DIFF
--- a/src/api/auth.ts
+++ b/src/api/auth.ts
@@ -34,6 +34,15 @@ export const postSignUp = async (id: string, pw: string, name: string) => {
   }
 };
 
+export const checkIdDuplication = async (id: string) => {
+  try {
+    const res = await axios.post(`${SERVER_URL}/check/id`, {id: id}, {headers: headers});
+    return res.data;
+  } catch {
+    return false;
+  }
+};
+
 // 인증 관련 코드
 
 const authHeaders = {

--- a/src/api/auth.ts
+++ b/src/api/auth.ts
@@ -1,7 +1,7 @@
 import axios from 'axios';
 import {SERVER_URL, USER_DEFAULT_IMG} from '../constant';
 
-const headers = {
+export const headers = {
   'content-type': 'application/json',
   serverId: process.env.REACT_APP_SERVER_ID,
 };
@@ -45,7 +45,7 @@ export const checkIdDuplication = async (id: string) => {
 
 // 인증 관련 코드
 
-const authHeaders = {
+export const authHeaders = {
   'content-type': 'application/json',
   serverId: process.env.REACT_APP_SERVER_ID,
   Authorization: 'Bearer ' + localStorage.getItem('accessToken'),

--- a/src/components/signIn/SignInBox.tsx
+++ b/src/components/signIn/SignInBox.tsx
@@ -37,9 +37,9 @@ const SignInBox = () => {
       </StyledNavBar>
       <StyledForm>
         <StyledLabel>아이디</StyledLabel>
-        <StyledInput name="id" value={id} onChange={onChange}></StyledInput>
+        <StyledInput name="id" value={id} onChange={onChange} autoComplete="off"></StyledInput>
         <StyledLabel>비밀번호</StyledLabel>
-        <StyledInput name="pw" type="password" value={pw} onChange={onChange}></StyledInput>
+        <StyledInput name="pw" type="password" value={pw} onChange={onChange} autoComplete="off"></StyledInput>
         <StyledSubmit onClick={signIn}>로그인</StyledSubmit>
       </StyledForm>
     </StyledContainer>
@@ -53,7 +53,6 @@ const StyledContainer = styled.div`
   width: 70%;
   max-width: 500px;
   min-height: 500px;
-  background-color: ${theme.colors.blue100};
   box-shadow: ${theme.shadows.shadow3.shadow};
   border-radius: 8px;
 `;
@@ -77,11 +76,12 @@ const StyledSignUpNav = styled.button`
   height: 4rem;
   border: none;
   border-radius: 8px 8px 0 0;
-  background-color: ${theme.colors.blue200};
+  background-color: ${theme.colors.gray100};
+  color: ${theme.colors.gray600};
   font-size: ${theme.fonts.body1.fontSize};
   font-weight: 800;
   &:hover {
-    background-color: ${theme.colors.blue300};
+    background-color: ${theme.colors.blue200};
   }
 `;
 
@@ -96,15 +96,14 @@ const StyledForm = styled.div`
 const StyledLabel = styled.label`
   align-self: flex-start;
   font-size: ${theme.fonts.body1.fontSize};
-  font-weight: 700;
-  margin: 1.5rem 0rem 1rem 0rem;
+  margin: 1.5rem 0rem 0.5rem 0rem;
 `;
 
 const StyledInput = styled.input`
   width: 100%;
-  height: 2.5rem;
+  height: 3rem;
   padding: 1rem;
-  border: 1px solid ${theme.colors.gray500};
+  border: 1px solid ${theme.colors.gray400};
   border-radius: 4px;
   outline: none;
 `;
@@ -117,7 +116,7 @@ const StyledSubmit = styled.button`
   border-radius: 8px;
   background-color: ${theme.colors.blue700};
   color: ${theme.colors.white};
-  font-size: ${theme.fonts.subtitle5.fontSize};
+  font-size: ${theme.fonts.subtitle4.fontSize};
   font-weight: 800;
 
   &:hover {

--- a/src/components/signIn/SignInBox.tsx
+++ b/src/components/signIn/SignInBox.tsx
@@ -4,9 +4,14 @@ import {theme} from '../../styles/Theme';
 import {useNavigate} from 'react-router';
 import {postSignIn} from '../../api/auth';
 
+interface Inputs {
+  id: string;
+  pw: string;
+}
+
 const SignInBox = () => {
   const navigate = useNavigate();
-  const [inputs, setInputs] = useState<any>({
+  const [inputs, setInputs] = useState<Inputs>({
     id: '',
     pw: '',
   });

--- a/src/components/signUp/SignUpBox.tsx
+++ b/src/components/signUp/SignUpBox.tsx
@@ -66,6 +66,7 @@ const SignUpBox = () => {
           placeholder="20자 이하의 이름을 입력해주세요"
           value={name}
           onChange={onChange}
+          autoComplete="off"
         ></StyledInput>
         <StyledLabel>아이디</StyledLabel>
         <StyledInput
@@ -73,6 +74,7 @@ const SignUpBox = () => {
           placeholder="영문으로 이루어진 아이디를 입력해주세요"
           value={id}
           onChange={onChange}
+          autoComplete="off"
         ></StyledInput>
         <StyledLabel>비밀번호</StyledLabel>
         <StyledPwInput
@@ -81,15 +83,17 @@ const SignUpBox = () => {
           value={pw}
           type="password"
           onChange={onChange}
+          autoComplete="off"
           isError={pwErrorMessage}
         ></StyledPwInput>
-        <StyledLabel style={{marginTop: '0.8rem'}}>비밀번호 확인</StyledLabel>
+        <StyledLabel>비밀번호 확인</StyledLabel>
         <StyledPwInput
           name="pw2"
           placeholder="5자리 이상의 비밀번호를 입력해주세요"
           value={pw2}
           type="password"
           onChange={onChange}
+          autoComplete="off"
           isError={pwErrorMessage}
         ></StyledPwInput>
         <StyledPwAlarm>{pwErrorMessage}</StyledPwAlarm>
@@ -106,7 +110,6 @@ const StyledContainer = styled.div`
   width: 70%;
   max-width: 500px;
   min-height: 500px;
-  background-color: ${theme.colors.blue100};
   box-shadow: ${theme.shadows.shadow3.shadow};
   border-radius: 8px;
 `;
@@ -121,12 +124,13 @@ const StyledSignInNav = styled.button`
   height: 4rem;
   border: none;
   border-radius: 8px 8px 0 0;
-  background-color: ${theme.colors.blue200};
+  background-color: ${theme.colors.gray100};
+  color: ${theme.colors.gray600};
   font-size: ${theme.fonts.body1.fontSize};
   font-weight: 800;
 
   &:hover {
-    background-color: ${theme.colors.blue300};
+    background-color: ${theme.colors.blue200};
   }
 `;
 
@@ -150,13 +154,12 @@ const StyledForm = styled.div`
 const StyledLabel = styled.label`
   align-self: flex-start;
   font-size: ${theme.fonts.body1.fontSize};
-  font-weight: 700;
-  margin: 1.5rem 0rem 1rem 0rem;
+  margin: 2rem 0rem 0.5rem 0rem;
 `;
 
 const StyledInput = styled.input`
   width: 100%;
-  height: 2.5rem;
+  height: 3rem;
   padding: 1rem;
   border: 1px solid ${theme.colors.gray500};
   border-radius: 4px;
@@ -165,7 +168,7 @@ const StyledInput = styled.input`
 
 const StyledPwInput = styled.input<Props>`
   width: 100%;
-  height: 2.5rem;
+  height: 3rem;
   padding: 1rem;
   border: 1px solid ${props => (props.isError ? theme.colors.error : theme.colors.gray500)};
   border-radius: 4px;
@@ -180,7 +183,7 @@ const StyledSubmit = styled.button`
   border-radius: 8px;
   background-color: ${theme.colors.blue700};
   color: ${theme.colors.white};
-  font-size: ${theme.fonts.subtitle5.fontSize};
+  font-size: ${theme.fonts.subtitle4.fontSize};
   font-weight: 800;
 
   &:hover {

--- a/src/pages/SignIn.tsx
+++ b/src/pages/SignIn.tsx
@@ -3,33 +3,41 @@ import SignInBox from '../components/signIn/SignInBox';
 
 const SignIn = () => {
   return (
-    <Container>
-      <TextSection>8lack</TextSection>
-      <SignInSection>
+    <StyledContainer>
+      <StyledTextSection>8lack</StyledTextSection>
+      <StyledSignInSection>
         <SignInBox />
-      </SignInSection>
-    </Container>
+      </StyledSignInSection>
+    </StyledContainer>
   );
 };
 
-const Container = styled.div`
+const StyledContainer = styled.div`
   display: flex;
 `;
 
-const TextSection = styled.div`
+const StyledTextSection = styled.div`
   display: flex;
   justify-content: center;
   align-items: center;
   width: 50%;
   height: 100vh;
+
+  @media screen and (max-width: 990px) {
+    display: none;
+  }
 `;
 
-const SignInSection = styled.div`
+const StyledSignInSection = styled.div`
   display: flex;
   justify-content: center;
   align-items: center;
   width: 50%;
   height: 100vh;
+
+  @media screen and (max-width: 990px) {
+    width: 100%;
+  }
 `;
 
 export default SignIn;

--- a/src/pages/SignUp.tsx
+++ b/src/pages/SignUp.tsx
@@ -3,33 +3,41 @@ import SignUpBox from '../components/signUp/SignUpBox';
 
 const SignUp = () => {
   return (
-    <Container>
-      <TextSection>8lack</TextSection>
-      <SignInSection>
+    <StyledContainer>
+      <StyledTextSection>8lack</StyledTextSection>
+      <StyledSignInSection>
         <SignUpBox />
-      </SignInSection>
-    </Container>
+      </StyledSignInSection>
+    </StyledContainer>
   );
 };
 
-const Container = styled.div`
+const StyledContainer = styled.div`
   display: flex;
 `;
 
-const TextSection = styled.div`
+const StyledTextSection = styled.div`
   display: flex;
   justify-content: center;
   align-items: center;
   width: 50%;
   height: 100vh;
+
+  @media screen and (max-width: 990px) {
+    display: none;
+  }
 `;
 
-const SignInSection = styled.div`
+const StyledSignInSection = styled.div`
   display: flex;
   justify-content: center;
   align-items: center;
   width: 50%;
   height: 100vh;
+
+  @media screen and (max-width: 990px) {
+    width: 100%;
+  }
 `;
 
 export default SignUp;


### PR DESCRIPTION
## 작업내용
Close #3 

- 아이디 중복체크 기능 추가
- 디자인 보완
- any타입 수정

<br>

## 주요 변경점 

-  회원가입 시 아이디를 중복체크할 수 있습니다.
-  중복확인을 통해 통과하지 않으면, 회원가입 진행이 안되도록 했습니다.
-  회원가입 창에서 아이디 필드를 상단으로 올렸습니다.

<img width="400px" height="550px" src="https://github.com/turkey-kim/8lack/assets/83493231/4600b96f-d241-47d0-bda3-c55af73f5487" />
<img width="400px" height="550px" src="https://github.com/turkey-kim/8lack/assets/83493231/9838acd0-df24-42a4-bdfb-694c79b0f741" />

<br>

## 유의할 점 (optional)

<br>

## To Reviewers (optional)

- 기능 구현에 신경쓰다보니 코드를 깔끔하게 작성하지 못해서, 주말에 리펙토링 해보려 합니다
   +  저번 Pr에 추천주신  input 상수화해서 관리 방법, input 마다 상이한 액션을 추가하다보니 적용해보기가 어려웠네요 ㅜ
       주말에 이어서 해보려합니다!
   +  코드 관련한 추가적인 피드백 주시면, 반영해보겠습니다!
