### PR TITLE
[#20] 회원 인증 기능 및 로그아웃 기능 구현

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,6 +28,7 @@
         "react-router-dom": "^6.18.0",
         "react-scripts": "5.0.1",
         "recoil": "^0.7.7",
+        "recoil-persist": "^5.1.0",
         "socket.io-client": "^4.7.2",
         "styled-components": "^6.1.0",
         "timeago.js": "^4.0.2",
@@ -14862,6 +14863,14 @@
         "react-native": {
           "optional": true
         }
+      }
+    },
+    "node_modules/recoil-persist": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/recoil-persist/-/recoil-persist-5.1.0.tgz",
+      "integrity": "sha512-sew4k3uBVJjRWKCSFuBw07Y1p1pBOb0UxLJPxn4G2bX/9xNj+r2xlqYy/BRfyofR/ANfqBU04MIvulppU4ZC0w==",
+      "peerDependencies": {
+        "recoil": "^0.7.2"
       }
     },
     "node_modules/recursive-readdir": {

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "react-router-dom": "^6.18.0",
     "react-scripts": "5.0.1",
     "recoil": "^0.7.7",
+    "recoil-persist": "^5.1.0",
     "socket.io-client": "^4.7.2",
     "styled-components": "^6.1.0",
     "timeago.js": "^4.0.2",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,14 +3,17 @@ import styled from 'styled-components';
 import {Outlet} from 'react-router-dom';
 import Navigation from './components/Navigation/Navigation';
 import SideBar from './components/SideBar/SideBar';
+import UserPublicRoute from 'routes/UserPublicRoute';
 
 function App() {
   return (
-    <StyledContainer>
-      <Navigation />
-      <SideBar />
-      <Outlet />
-    </StyledContainer>
+    <UserPublicRoute>
+      <StyledContainer>
+        <Navigation />
+        <SideBar />
+        <Outlet />
+      </StyledContainer>
+    </UserPublicRoute>
   );
 }
 

--- a/src/api/auth.ts
+++ b/src/api/auth.ts
@@ -6,6 +6,15 @@ export const headers = {
   serverId: process.env.REACT_APP_SERVER_ID,
 };
 
+export const authHeaders = () => {
+  const accessToken = localStorage.getItem('accessToken');
+  return {
+    'content-type': 'application/json',
+    serverId: process.env.REACT_APP_SERVER_ID,
+    Authorization: `Bearer ${accessToken}`,
+  };
+}; // 토큰이 필요한 api에는 해당 헤더를 사용하시면 됩니다!
+
 export const postSignIn = async (id: string, pw: string) => {
   try {
     const response = await axios.post(
@@ -44,18 +53,13 @@ export const checkIdDuplication = async (id: string) => {
 };
 
 // 인증 관련 코드
-
-export const authHeaders = {
-  'content-type': 'application/json',
-  serverId: process.env.REACT_APP_SERVER_ID,
-  Authorization: 'Bearer ' + localStorage.getItem('accessToken'),
-}; // 토큰이 필요한 api에는 해당 헤더를 사용하시면 됩니다!
-
 export const authCheck = async () => {
   try {
-    const res = await axios.get(`${SERVER_URL}/auth/me`, {headers: authHeaders});
+    const res = await axios.get(`${SERVER_URL}/auth/me`, {
+      headers: authHeaders(),
+    });
     return res.data;
   } catch (err) {
-    console.log(err);
+    return false;
   }
 };

--- a/src/components/Navigation/Navigation.tsx
+++ b/src/components/Navigation/Navigation.tsx
@@ -4,9 +4,18 @@ import Logo from '../../assets/icons/Logo.png';
 import Chat from '../../assets/icons/Chat.svg';
 import MyPage from '../MyPage/MyPage';
 import {useState} from 'react';
+import {loginState} from 'states/atom';
+import {useRecoilState} from 'recoil';
 
 export default function Navigation() {
   const [isModalOpen, setIsModalOpen] = useState(false);
+  const [isLoggedIn, setIsLoggedIn] = useRecoilState(loginState);
+
+  const logOut = () => {
+    localStorage.removeItem('accessToken');
+    localStorage.removeItem('refreshToken');
+    setIsLoggedIn(false);
+  };
 
   return (
     <StyledNav>
@@ -29,7 +38,7 @@ export default function Navigation() {
         </div>
         <MyPage isOpen={isModalOpen} onRequestClose={() => setIsModalOpen(false)} />
       </StyledIconContainer>
-      <StyledLogout>로그아웃</StyledLogout>
+      <StyledLogout onClick={logOut}>로그아웃</StyledLogout>
     </StyledNav>
   );
 }

--- a/src/components/signIn/SignInBox.tsx
+++ b/src/components/signIn/SignInBox.tsx
@@ -3,6 +3,8 @@ import styled from 'styled-components';
 import {theme} from '../../styles/Theme';
 import {useNavigate} from 'react-router';
 import {postSignIn} from '../../api/auth';
+import {useRecoilState} from 'recoil';
+import {loginState} from 'states/atom';
 
 interface Inputs {
   id: string;
@@ -10,6 +12,7 @@ interface Inputs {
 }
 
 const SignInBox = () => {
+  const [isLogged, setIsLogged] = useRecoilState(loginState);
   const navigate = useNavigate();
   const [inputs, setInputs] = useState<Inputs>({
     id: '',
@@ -26,6 +29,7 @@ const SignInBox = () => {
     const {accessToken, refreshToken} = res;
     localStorage.setItem('accessToken', accessToken);
     localStorage.setItem('refreshToken', refreshToken);
+    setIsLogged(true);
     navigate('/');
   };
 

--- a/src/hooks/useAuthCheck.ts
+++ b/src/hooks/useAuthCheck.ts
@@ -1,0 +1,31 @@
+import {useEffect, useState} from 'react';
+import {authCheck} from 'api/auth';
+import {useRecoilValue} from 'recoil';
+import {loginState} from 'states/atom';
+
+const useAuthCheck = () => {
+  const [authorization, setAuthorization] = useState(false); // 토큰 유효성 여부
+  const [isLoading, setIsLoading] = useState(true); // 로딩 지연 여부
+  const isLoggedIn = useRecoilValue(loginState);
+
+  useEffect(() => {
+    const fetch = async () => {
+      const res = await authCheck();
+      console.log(res.auth);
+      if (res.auth) {
+        setIsLoading(false);
+        setAuthorization(true);
+      } else {
+        setIsLoading(false);
+        setAuthorization(false);
+      }
+    };
+
+    fetch();
+  }, [isLoggedIn]); // 의존성 배열에 로그인 스테이트 연결
+
+  return {authorization, isLoading};
+};
+// 해당 훅을 사용하는 모든 컴포넌트는 전역 로그인스테이트를 구독하게됩니다! (로그인스테이트가 바뀔 때마다 렌더링)
+
+export default useAuthCheck;

--- a/src/hooks/useAuthCheck.ts
+++ b/src/hooks/useAuthCheck.ts
@@ -1,12 +1,12 @@
 import {useEffect, useState} from 'react';
 import {authCheck} from 'api/auth';
-import {useRecoilValue} from 'recoil';
+import {useRecoilState} from 'recoil';
 import {loginState} from 'states/atom';
 
 const useAuthCheck = () => {
   const [authorization, setAuthorization] = useState(false); // 토큰 유효성 여부
   const [isLoading, setIsLoading] = useState(true); // 로딩 지연 여부
-  const isLoggedIn = useRecoilValue(loginState);
+  const [isLoggedIn, setIsLoggedIn] = useRecoilState(loginState);
 
   useEffect(() => {
     const fetch = async () => {
@@ -18,6 +18,9 @@ const useAuthCheck = () => {
       } else {
         setIsLoading(false);
         setAuthorization(false);
+        if (isLoggedIn) {
+          setIsLoggedIn(false);
+        }
       }
     };
 

--- a/src/routes/UserPublicRoute.tsx
+++ b/src/routes/UserPublicRoute.tsx
@@ -1,0 +1,17 @@
+import {ReactElement} from 'react';
+import {Navigate} from 'react-router';
+import useAuthCheck from 'hooks/useAuthCheck';
+
+interface Props {
+  children: ReactElement;
+}
+
+const UserPublicRoute = ({children}: Props): any => {
+  const {isLoading, authorization} = useAuthCheck();
+
+  if (isLoading && !authorization) return <>...is Loading</>;
+  if (!isLoading && authorization) return children;
+  if (!isLoading && !authorization) return <Navigate to="/signin" />;
+};
+
+export default UserPublicRoute;

--- a/src/states/atom.ts
+++ b/src/states/atom.ts
@@ -1,1 +1,13 @@
 import {atom} from 'recoil';
+import {recoilPersist} from 'recoil-persist';
+
+const {persistAtom} = recoilPersist({
+  key: 'localStorage',
+  storage: localStorage,
+});
+
+export const loginState = atom({
+  key: 'loginState',
+  default: false,
+  effects_UNSTABLE: [persistAtom],
+});


### PR DESCRIPTION
## 작업내용

- 회원 인증 구현 
-  유저 전용 페이지 라우팅 구현
     ( **이제부터 로그인한 유저만 서비스 사용할 수 있음** )
- 로그아웃 구현

close #20
<br>

## 주요 변경점 

### 1. 회원인증 구현
   #### useAuthCheck 커스텀훅 추가 (경로 :src/hooks/useAuthCheck.ts )
   필수구현사항을 고려해 커스텀훅으로 추가했습니다 
   
![스크린샷 2023-11-10 오전 12 01 13](https://github.com/turkey-kim/8lack/assets/83493231/18847bcb-bfd3-4c03-b03f-7cbb75fe88ee)
  useEffect를 사용한 커스텀훅입니다. 

 토큰 유효성 검사 API를 통해, 클라이언트의 유저인증여부를 상태값으로 반환합니다! ( authorization )
 비동기 처리 로직이므로, 반환 결과에 대한 로딩상태 또한 반환합니다! (  isLoading )

 의존성 배열에 '로그인 전역 상태'를 넣었습니다! (해당 로직은 로그인 전역 상태가 바뀔 때마다 작동됩니다)

<br/>

### 2. 유저 전용 페이지 라우팅
#### UserPublicRoute 컴포넌트 추가 (경로: src/routes/UserPublicRoute.tsx)
![스크린샷 2023-11-10 오전 12 11 26](https://github.com/turkey-kim/8lack/assets/83493231/97e89b2e-1c16-4a05-8b2e-d1e5ce2df6a4)
위에 작성한 커스텀훅을 활용했습니다
유저의 로그인 여부를 판단하여, 로그인되지 않은 상태라면 로그인페이지로 이동시킵니다.
로딩 중에는 로딩 컴포넌트를 띄웁니다.

**아래의 사진처럼 해당 라우터는 App.tsx 컴포넌트 안에 배치했습니다!**

<img width="600px" src="https://github.com/turkey-kim/8lack/assets/83493231/4369db90-a390-4db1-b7fa-79773c1afaa4" />


<br/>

### 3. 로그아웃 구현
![스크린샷 2023-11-10 오전 12 19 11](https://github.com/turkey-kim/8lack/assets/83493231/a5f3f233-1f1b-46fd-9e3c-45f95236f0dc)

: 위의 사진과 같이 Navigation 컴포넌트에 로그아웃 함수를 작성하여, 로그아웃 버튼과 연동하였습니다!
: 해당 컴포넌트에서 로그인 전역 상태를 구독하도록 했고,
   로그아웃을 누르면 로컬스토리지의 토큰을 정리하고 로그인 전역상태를 바꿔줍니다!

<br/>

## 유의할 점 (optional)

- Recoil-persist 설치했으므로, npm ci 해주세요!

- 로컬에서 구동하시기 전에, 
  로컬 스토리지의 토큰들을 삭제해주신 후 실행시켜주세요! 

- 현재 앱최상단에 UserPublicRouter를 배치했고, 그 안에서 돌아가는 커스텀훅은 '로그인 전역 상태'를 의존성 배열로 두고 있습니다!
   따라서 회원 인증은 2 가지 경우에 작동합니다.
   - 홈페이지 최초 접속 ( 새로고침 )
   - 로그인 전역 상태가 바뀔 경우 ( 로그인 or 로그아웃할 경우 )
<br>

## To Reviewers (optional)

- 확인 후 리뷰부탁드립니다!
