### PR TITLE
[#28] 홈화면 접속 시 소켓 연결

### DIFF
--- a/src/routes/UserPublicRoute.tsx
+++ b/src/routes/UserPublicRoute.tsx
@@ -1,6 +1,18 @@
 import {ReactElement, useEffect} from 'react';
 import {Navigate} from 'react-router';
 import useAuthCheck from 'hooks/useAuthCheck';
+import {useRecoilState} from 'recoil';
+import {onlineUserList} from 'states/atom';
+import {io} from 'socket.io-client';
+import {SERVER_URL} from 'constant';
+
+const socketHeaders = () => {
+  const accessToken = localStorage.getItem('accessToken');
+  return {
+    Authorization: `Bearer ${accessToken}`,
+    serverId: process.env.REACT_APP_SERVER_ID as string,
+  };
+}; // 소켓 전용 토큰
 
 interface Props {
   children: ReactElement;
@@ -8,6 +20,24 @@ interface Props {
 
 const UserPublicRoute = ({children}: Props): any => {
   const {authorization, isLoading} = useAuthCheck();
+  const [onlineUsers, setOnlineUsers] = useRecoilState(onlineUserList);
+
+  useEffect(() => {
+    const socket = io(`${SERVER_URL}/server`, {
+      extraHeaders: socketHeaders(),
+    });
+    socket.on('users-server-to-client', ({users}) => {
+      setOnlineUsers(users);
+    });
+
+    return () => {
+      socket.disconnect();
+    }; // 홈화면 언마운트(로그아웃) 시, 소켓 닫음.
+  }, []);
+
+  useEffect(() => {
+    console.log(onlineUsers);
+  }, [onlineUsers]); // 온라인 유저리스트 불러오기 테스트 코드 (삭제 예정)
 
   if (isLoading && !authorization) return <>...is Loading</>;
   if (!isLoading && authorization) return children;

--- a/src/states/atom.ts
+++ b/src/states/atom.ts
@@ -16,3 +16,8 @@ export const userInformation = atom({
   key: 'userInformation',
   default: {},
 });
+
+export const onlineUserList = atom({
+  key: 'onlineUserList',
+  default: [],
+});


### PR DESCRIPTION
## 작업내용

회의하고나서, 테스트 코드 삭제 및 일부 수정 후 머지하려합니다! 
자세한 내용은 회의 때 한 번 더 말씀드리겠습니다!
close #28 

- 홈 화면 접속 시 소켓 연결
- 실시간 유저리스트 받아오기
- 받아온 유저 리스트 리코일에 저장(실시간으로 반영)
<br>

## 주요 변경점 

### 1. 홈 화면 접속 시 소켓 연결
모든 서비스 페이지는 UserPublicRoute를 거쳐가므로, 해당 컴포넌트 내에 소켓 연결 로직을 작성했습니다
useEffect를 사용하여 마운트될 때 소켓을 연결 후 유저 리스트를 받아 리코일 전역상태로 저장합니다. 
그리고 언마운트될 때는 소켓을 끊도록 했습니다! 

(src/routes/UserPublicRoute.tsx)
![스크린샷 2023-11-10 오후 5 43 22](https://github.com/turkey-kim/8lack/assets/83493231/66771ae3-1c7a-46b1-bc62-fba6d86736d1)


### 2. 실시간 유저 목록 전역상태화 ( 경로: src/states/atoms.ts )
실시간 유저목록을 아래의 전역상태에 저장합니다!
실시간 유저목록을 받아오고 싶은 컴포넌트에서 가져다 쓰시면 됩니다!

![스크린샷 2023-11-10 오후 5 46 22](https://github.com/turkey-kim/8lack/assets/83493231/69cbd8d6-303e-42a4-ab59-d45770574de8)

### 3. 반환 데이터
서버 측에서 아래와 같이, 유저의 아이디로만 접속 유저 목록을 반환하고 있습니다!

<img width="845" alt="스크린샷 2023-11-10 오후 4 01 02" src="https://github.com/turkey-kim/8lack/assets/83493231/70ecc1ab-6bdb-4fce-a714-157c4b4d7710">

<br>

## 유의할 점 (optional)

- 소켓을 써보니, 소켓에 대한 또 다른 헤더가 나왔습니다.
   -  api 헤더만 모아두는 파일을 따로 만들어 관리하는게 어떨까 생각합니다! 회의에서 이야기해봐요!
   
- 채팅방 소켓이랑 잘 연동이 되는지는 확인해봐야할 것 같습니다! (잘됐으면 좋겠네요ㅜ)
<br>

## To Reviewers (optional)

- 확인 부탁드립니다! 
