### PR TITLE
[#9] 사이드바 - 개인 채팅 구현

### DIFF
--- a/src/api/myChatRoom.ts
+++ b/src/api/myChatRoom.ts
@@ -1,15 +1,10 @@
 import axios from 'axios';
-
-const headers = {
-  'content-type': 'application/json',
-  serverId: process.env.REACT_APP_SERVER_ID,
-  Authorization: 'Bearer ' + localStorage.getItem('accessToken'),
-};
+import {authHeaders} from './auth';
+import {SERVER_URL} from 'constant';
 
 export const myChatRoom = async () => {
   try {
-    const response = await axios.get('https://fastcampus-chat.net/chat', {headers: headers});
-    console.log(response);
+    const response = await axios.get(`${SERVER_URL}/chat`, {headers: authHeaders()});
     return response.data;
   } catch (err) {
     alert('⚠️예기치 못한 에러가 발생하였습니다.');

--- a/src/components/GroupChat/GroupChat.tsx
+++ b/src/components/GroupChat/GroupChat.tsx
@@ -1,0 +1,113 @@
+import React from 'react';
+import styled from 'styled-components';
+import {theme} from '../../styles/Theme';
+import {format, register} from 'timeago.js';
+import koLocale from 'timeago.js/lib/lang/ko';
+
+register('ko', koLocale);
+
+export interface Chat {
+  id: string;
+  name: string;
+  users: User[]; // 속한 유저 id
+  isPrivate: boolean;
+  latestMessage: Message | null;
+  updatedAt: Date;
+}
+
+interface User {
+  id: string;
+  name: string;
+  picture: string;
+}
+
+interface Message {
+  id: string;
+  text: string;
+  userId: string;
+  createdAt: Date;
+}
+
+interface Props {
+  key: string;
+  data: Chat;
+}
+
+export default function GroupChat(props: Props) {
+  // const [privateRooms, setPrivateRooms] = useState<Chat[]>(dummyPrivateRooms);
+  const {id, name, updatedAt, latestMessage, users} = props.data;
+  return (
+    <StyledContainer>
+      <StyledSubContainer>
+        <StyledImg src={users[1].picture} alt="사용자 프로필 이미지" />
+        <StyledTextContainer>
+          <StyledTitle>{name}</StyledTitle>
+          <StyledText>{latestMessage?.text}</StyledText>
+        </StyledTextContainer>
+      </StyledSubContainer>
+      <StyledDiv>
+        <StyledDate>{format(updatedAt, 'ko')}</StyledDate>
+        {latestMessage === null ? '' : <StyledLatestMessage />}
+      </StyledDiv>
+    </StyledContainer>
+  );
+}
+
+const StyledContainer = styled.li`
+  display: flex;
+  justify-content: space-around;
+  width: 100%;
+  padding: 1rem 0;
+  background-color: white;
+  cursor: pointer;
+  transition: all 0.3s ease-out;
+  &:hover {
+    background-color: ${theme.colors.blue100};
+  }
+`;
+
+const StyledSubContainer = styled.div`
+  display: flex;
+  gap: 1rem;
+`;
+
+const StyledImg = styled.img`
+  width: 4rem;
+  height: 4rem;
+`;
+
+const StyledTextContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: space-around;
+  padding: 0.5rem;
+`;
+
+const StyledTitle = styled.h2`
+  font-size: ${props => props.theme.fonts.subtitle5.fontSize};
+`;
+
+const StyledText = styled.p`
+  font-size: ${props => props.theme.fonts.body2.fontSize};
+`;
+
+const StyledDiv = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  align-items: flex-end;
+`;
+
+const StyledDate = styled.p`
+  margin-top: 0.5rem;
+  font-size: ${props => props.theme.fonts.body2.fontSize};
+  color: ${props => props.theme.colors.gray600};
+`;
+
+const StyledLatestMessage = styled.div`
+  margin-bottom: 0.625rem;
+  width: 0.875rem;
+  height: 0.875rem;
+  border-radius: 50%;
+  background-color: ${theme.colors.pink800};
+`;

--- a/src/components/GroupChat/GroupChats.tsx
+++ b/src/components/GroupChat/GroupChats.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import {dummyPrivateRooms} from '../PrivateChat/dummyPrivateRooms';
+import GroupChat from './GroupChat';
+
+export default function GroupChats() {
+  return (
+    <ul>
+      {dummyPrivateRooms.map(room => {
+        return !room.isPrivate && <GroupChat key={room.id} data={room} />;
+      })}
+    </ul>
+  );
+}

--- a/src/components/PrivateChat/PrivateChat.tsx
+++ b/src/components/PrivateChat/PrivateChat.tsx
@@ -1,7 +1,27 @@
+import {useState, useEffect} from 'react';
 import styled from 'styled-components';
 import {theme} from '../../styles/Theme';
-import {USER_DEFAULT_IMG} from '../../constant';
-import {dummyPrivateRooms} from './dummyPrivateRooms';
+import {authCheck} from '../../api/auth';
+import {format, register} from 'timeago.js';
+import koLocale from 'timeago.js/lib/lang/ko';
+import {myChatRoom} from 'api/myChatRoom';
+
+register('ko', koLocale);
+
+export interface Chat {
+  id: string;
+  name: string;
+  users: User[]; // 속한 유저 id
+  isPrivate: boolean;
+  latestMessage: Message | null;
+  updatedAt: Date;
+}
+
+interface User {
+  id: string;
+  name: string;
+  picture: string;
+}
 
 interface Message {
   id: string;
@@ -10,26 +30,32 @@ interface Message {
   createdAt: Date;
 }
 
-export default function PrivateChat() {
-  const lastMessage = dummyPrivateRooms.map(dummyPrivateRoom => dummyPrivateRoom.latestMessage.createdAt);
-  console.log(lastMessage);
-  // const {createdAt}: Message = lastMessage;
-  // console.log(createdAt);
+interface Props {
+  key: string;
+  data: Chat;
+}
+
+export default function PrivateChat(props: Props) {
+  const {id, name, updatedAt, latestMessage, users} = props.data;
+
   return (
     <StyledContainer>
       <StyledSubContainer>
-        <StyledImg src={USER_DEFAULT_IMG} alt="사용자 프로필 이미지" />
+        <StyledImg src={users[1].picture} alt="사용자 프로필 이미지" />
         <StyledTextContainer>
-          <StyledTitle>나와의 채팅</StyledTitle>
-          <StyledText>마지막으로 적은 텍스트...</StyledText>
+          <StyledTitle>{users[1].name}</StyledTitle>
+          <StyledText>{latestMessage?.text}</StyledText>
         </StyledTextContainer>
       </StyledSubContainer>
-      <StyledDate>지금</StyledDate>
+      <StyledDiv>
+        <StyledDate>{format(updatedAt, 'ko')}</StyledDate>
+        {latestMessage === null ? '' : <StyledLatestMessage />}
+      </StyledDiv>
     </StyledContainer>
   );
 }
 
-const StyledContainer = styled.div`
+const StyledContainer = styled.li`
   display: flex;
   justify-content: space-around;
   width: 100%;
@@ -67,8 +93,23 @@ const StyledText = styled.p`
   font-size: ${props => props.theme.fonts.body2.fontSize};
 `;
 
+const StyledDiv = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  align-items: flex-end;
+`;
+
 const StyledDate = styled.p`
   margin-top: 0.5rem;
   font-size: ${props => props.theme.fonts.body2.fontSize};
   color: ${props => props.theme.colors.gray600};
+`;
+
+const StyledLatestMessage = styled.div`
+  margin-bottom: 0.625rem;
+  width: 0.875rem;
+  height: 0.875rem;
+  border-radius: 50%;
+  background-color: ${theme.colors.pink800};
 `;

--- a/src/components/PrivateChat/PrivateChats.tsx
+++ b/src/components/PrivateChat/PrivateChats.tsx
@@ -1,12 +1,21 @@
-import PrivateChat from './PrivateChat';
+import {useEffect, useState} from 'react';
+import PrivateChat, {Chat} from './PrivateChat';
 import {dummyPrivateRooms} from './dummyPrivateRooms';
 
 export default function PrivateChats() {
+  const [sortedChat, setSortedChat] = useState<Chat[]>([]);
+
+  useEffect(() => {
+    const sorted = [...dummyPrivateRooms]
+      .filter(room => room.isPrivate)
+      .sort((a, b) => b.updatedAt.getTime() - a.updatedAt.getTime());
+    setSortedChat(sorted);
+  }, []);
   return (
-    <div>
-      {dummyPrivateRooms.map(room => {
-        return <PrivateChat />;
-      })}
-    </div>
+    <ul>
+      {sortedChat.map(room => (
+        <PrivateChat key={room.id} data={room} />
+      ))}
+    </ul>
   );
 }

--- a/src/components/PrivateChat/dummyPrivateRooms.ts
+++ b/src/components/PrivateChat/dummyPrivateRooms.ts
@@ -10,26 +10,41 @@ export const dummyPrivateRooms = [
       },
       {
         id: 'user2',
-        name: '유머시기',
+        name: '장모락',
         picture: 'https://gravatar.com/avatar/d94869409b4e94903723612a4f93a6f9?s=200&d=retro',
       },
     ],
     isPrivate: true,
-    updatedAt: '2023-10-31T13:18:38.216Z',
-    latestMessage: {
-      id: '8f7f67bb-f1ab-4792-9678-0b8546adcb6f',
-      text: 'testtest444',
-      userId: 'test:test6',
-      createdAt: '2023-11-08T11:15:50.588+00:00',
-    },
+    updatedAt: new Date('2022-11-10'),
+    latestMessage: null,
   },
+  {
+    id: 'id123',
+    name: 'chat room 1ff',
+    users: [
+      {
+        id: 'user1',
+        name: '장수빈',
+        picture: 'https://gravatar.com/avatar/c274467c5ef4fe381b154a20c5e7ce26?s=200&d=retro',
+      },
+      {
+        id: 'user2',
+        name: '민모리',
+        picture: 'https://gravatar.com/avatar/d94869409b4e94903723612a4f93a6f9?s=200&d=retro',
+      },
+    ],
+    isPrivate: true,
+    updatedAt: new Date('2020-1-10'),
+    latestMessage: null,
+  },
+
   {
     id: 'id2',
     name: 'chat room 2',
     users: [
       {
         id: 'user122',
-        name: '박머시기',
+        name: '장수빈',
         picture: 'https://gravatar.com/avatar/c274467c5ef4fe381b154a20c5e7ce26?s=200&d=retro',
       },
       {
@@ -39,36 +54,36 @@ export const dummyPrivateRooms = [
       },
     ],
     isPrivate: false,
-    updatedAt: '2023-10-31T15:30:38.216Z',
+    updatedAt: new Date('2023-10-23'),
     latestMessage: {
       id: '8f7f67bb-f1ab-4792-9678-0b8546adcb6f',
-      text: 'testtest444',
+      text: '밥먹었니?',
       userId: 'test:test6',
-      createdAt: '2023-11-06T11:15:50.588+00:00',
+      createdAt: new Date(),
     },
   },
   {
-    id: 'id2',
-    name: 'chat room 2',
+    id: 'id3',
+    name: 'chat room 3',
     users: [
       {
-        id: 'user122',
-        name: '정머시기',
+        id: 'user1ffff22',
+        name: '장수빈',
         picture: 'https://gravatar.com/avatar/c274467c5ef4fe381b154a20c5e7ce26?s=200&d=retro',
       },
       {
-        id: 'user222',
-        name: '장머시기',
+        id: 'user2fff22',
+        name: '김파락',
         picture: 'https://gravatar.com/avatar/d94869409b4e94903723612a4f93a6f9?s=200&d=retro',
       },
     ],
     isPrivate: true,
-    updatedAt: '2023-10-31T15:30:38.216Z',
+    updatedAt: new Date('2023-11-10'),
     latestMessage: {
       id: '8f7f67bb-f1ab-4792-9678-0b8546adcb6f',
-      text: 'testtest444',
+      text: '뭐해?',
       userId: 'test:test6',
-      createdAt: '2023-11-06T11:15:50.588+00:00',
+      createdAt: new Date(),
     },
   },
 ];

--- a/src/components/SideBar/SideBar.tsx
+++ b/src/components/SideBar/SideBar.tsx
@@ -1,22 +1,42 @@
+import {useEffect, useState} from 'react';
 import styled from 'styled-components';
 import PrivateChats from '../PrivateChat/PrivateChats';
 import {theme} from '../../styles/Theme';
-import {dummyPrivateRooms} from '../PrivateChat/dummyPrivateRooms';
-import {useNavigate} from 'react-router-dom';
+import GroupChat from 'components/GroupChat/GroupChats';
+import {authCheck} from '../../api/auth';
 
 export default function SideBar() {
-  const navigate = useNavigate();
-  const privateRoom = dummyPrivateRooms.map(dummyPrivateRoom => dummyPrivateRoom.isPrivate).includes(true);
+  const [categoryButton, setCategoryButton] = useState<boolean>(true);
+  const [name, setName] = useState<string>('');
+
+  const getAuth = async () => {
+    const res = await authCheck();
+    setName(res.user.name);
+  };
+
+  useEffect(() => {
+    getAuth();
+  }, []);
 
   return (
     <StyledContainer>
-      <StyledText>안녕하세요. 김팔락님👋</StyledText>
+      <StyledText>안녕하세요. {name}님👋</StyledText>
       <StyledCategoryContainer>
-        <StyledPrivateText>개인</StyledPrivateText>
-        <StyledGroupText>그룹</StyledGroupText>
+        <StyledPrivateButton
+          className={categoryButton ? 'selected_category' : ''}
+          onClick={() => setCategoryButton(true)}
+        >
+          개인
+        </StyledPrivateButton>
+        <StyledGroupButton
+          className={!categoryButton ? 'selected_category' : ''}
+          onClick={() => setCategoryButton(false)}
+        >
+          그룹
+        </StyledGroupButton>
       </StyledCategoryContainer>
       <StyledLine />
-      <PrivateChats />
+      <StyledChatContainer>{categoryButton ? <PrivateChats /> : <GroupChat />}</StyledChatContainer>
     </StyledContainer>
   );
 }
@@ -25,7 +45,6 @@ const StyledContainer = styled.div`
   width: 24rem;
   border-left: 1px solid ${theme.colors.gray400};
   border-right: 1px solid ${theme.colors.gray400};
-  background-color: ${theme.colors.gray100};
 `;
 
 const StyledText = styled.h2`
@@ -37,20 +56,27 @@ const StyledCategoryContainer = styled.div`
   margin: 3.5rem 1.5rem 1rem 1.5rem;
   gap: 1.5rem;
   display: flex;
+
+  .selected_category {
+    color: ${theme.colors.blue700};
+  }
 `;
 
-const StyledPrivateText = styled.button`
-  font-size: ${theme.fonts.subtitle5.fontSize};
-  font-weight: ${theme.fonts.subtitle5.fontWeight};
-  color: ${theme.colors.blue700};
-`;
-
-const StyledGroupText = styled.button`
+const StyledPrivateButton = styled.button`
   font-size: ${theme.fonts.subtitle5.fontSize};
   font-weight: ${theme.fonts.subtitle5.fontWeight};
   color: ${theme.colors.blue500};
 `;
 
+const StyledGroupButton = styled(StyledPrivateButton)`
+  color: ${theme.colors.blue500};
+`;
+
 const StyledLine = styled.div`
   border-bottom: 1px solid ${theme.colors.gray400};
+`;
+
+const StyledChatContainer = styled.div`
+  height: 100vh;
+  background-color: ${theme.colors.gray100};
 `;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -11,7 +11,7 @@ import {createBrowserRouter, RouterProvider} from 'react-router-dom';
 import NotFound from './pages/NotFound';
 import Users from './pages/Users';
 import SignIn from './pages/SignIn';
-import SignUp from './pages/SignUp';
+import SignUp from 'pages/SignUp';
 import ChatRoom from 'pages/ChatRoom';
 import GroupChatList from './pages/GroupChatList';
 import Modal from 'react-modal';


### PR DESCRIPTION
close #9 

## 작업내용
- `updatedAt` 을 기준으로 최신순으로 채팅방 정렬
- 개인, 그룹 필터링
-`lastestMessage` 가 null 이 아닐 경우 메세지 표시
- `안녕하세요 @@@님`에 로그인한 유저 이름 표시 

<br>

## 주요 변경점 
- `개인` 탭 눌렀을 경우 : 최신순으로 정렬
![image](https://github.com/turkey-kim/8lack/assets/83440978/06e322e6-1355-4f50-82be-dcdc4dc10903)

- `그룹` 탭 눌렀을 경우
![image](https://github.com/turkey-kim/8lack/assets/83440978/d4422901-ae70-43d0-b9c4-c664bb7ac765)


<br>

## 유의할 점 (optional)
-  api 로직은 짜놨지만 아직 실제 데이터가 없어서 일단 더미데이터로 구현했습니다! 채팅방 get 해올 수 있을 때 api 연결해보겠습니당
<br>

## To Reviewers (optional)
1. 더미데이터에 있는 `latestMessage` 를 보니 읽음 여부 관계없이 마지막 메세지를 주는거 같은데 그렇다면 읽음 여부를 무엇으로 판단해야 할 지 고민입니당..
그리고 최근 메시지가 오면 채팅방 리스트에도 실시간으로 떠야하는데 소켓에는 이러한 구현사항이 존재하지 않아서 멘토님께 요청하거나 폴링방식으로 구현해야 할 거 같은데 같이 얘기해보면 좋을 거 같습니다..!

2. 1:1 채팅방을 구현할 땐 유저 목록에서 채팅창을 만드는데, "나와의 채팅"을 구현할 때, 혼자 방만드는 기능이 따로 없는데 어떤 식으로 진행하는 것이 좋을까요..?!
