### PR TITLE
[#41] 메인페이지에서 모든 채팅방 보기

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -5,11 +5,8 @@
     <link rel="icon" href="%PUBLIC_URL%/favicon.ico" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="theme-color" content="#000000" />
-    <meta
-      name="description"
-      content="Web site created using create-react-app"
-    />
-    <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" />
+    <meta name="description" content="Web site created using create-react-app" />
+    <!-- <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" /> -->
     <!--
       manifest.json provides metadata used when your web app is installed on a
       user's mobile device or desktop. See https://developers.google.com/web/fundamentals/web-app-manifest/

--- a/src/api/AllChatRoom.ts
+++ b/src/api/AllChatRoom.ts
@@ -1,0 +1,12 @@
+import axios from 'axios';
+import {authHeaders} from './auth';
+import {SERVER_URL} from '../constant/constant';
+
+export const allChatRoom = async () => {
+  try {
+    const response = await axios.get(`${SERVER_URL}/chat/all`, {headers: authHeaders()});
+    return response.data;
+  } catch (err) {
+    alert('⚠️예기치 못한 에러가 발생하였습니다.');
+  }
+};

--- a/src/api/myChatRoom.ts
+++ b/src/api/myChatRoom.ts
@@ -11,15 +11,6 @@ export const myChatRoom = async () => {
   }
 };
 
-export const allChatRoom = async () => {
-  try {
-    const response = await axios.get(`${SERVER_URL}/chat/all`, {headers: authHeaders()});
-    return response.data;
-  } catch (err) {
-    alert('⚠️예기치 못한 에러가 발생하였습니다.');
-  }
-};
-
 export const makeChatRoom = async (name: string, users: string[], isPrivate?: boolean) => {
   try {
     const response = await axios.post(

--- a/src/api/myChatRoom.ts
+++ b/src/api/myChatRoom.ts
@@ -14,7 +14,7 @@ export const myChatRoom = async () => {
 export const makeChatRoom = async (name: string, users: string[], isPrivate?: boolean) => {
   try {
     const response = await axios.post(
-      'https://fastcampus-chat.net/chat',
+      `${SERVER_URL}/chat`,
       {name: name, users: users, isPrivate: isPrivate},
       {headers: authHeaders()},
     );

--- a/src/api/myChatRoom.ts
+++ b/src/api/myChatRoom.ts
@@ -11,6 +11,15 @@ export const myChatRoom = async () => {
   }
 };
 
+export const allChatRoom = async () => {
+  try {
+    const response = await axios.get(`${SERVER_URL}/chat/all`, {headers: authHeaders()});
+    return response.data;
+  } catch (err) {
+    alert('⚠️예기치 못한 에러가 발생하였습니다.');
+  }
+};
+
 export const makeChatRoom = async (name: string, users: string[], isPrivate?: boolean) => {
   try {
     const response = await axios.post(

--- a/src/components/ChatRoomsList/ChatRoomsList.tsx
+++ b/src/components/ChatRoomsList/ChatRoomsList.tsx
@@ -1,4 +1,4 @@
-import {myChatRoom} from 'api/myChatRoom';
+import {allChatRoom} from 'api/myChatRoom';
 import ChatRoomEl from './ChatRoomEl';
 import styled from 'styled-components';
 import {useEffect, useState} from 'react';
@@ -16,7 +16,7 @@ const ChatLists = () => {
   const [chatRoomsList, setChatRoomsList] = useState<Chat[]>([]);
 
   useEffect(() => {
-    myChatRoom().then(res => {
+    allChatRoom().then(res => {
       setChatRoomsList(res.chats);
     });
   }, []);

--- a/src/components/ChatRoomsList/ChatRoomsList.tsx
+++ b/src/components/ChatRoomsList/ChatRoomsList.tsx
@@ -1,4 +1,4 @@
-import {allChatRoom} from 'api/myChatRoom';
+import {allChatRoom} from 'api/AllChatRoom';
 import ChatRoomEl from './ChatRoomEl';
 import styled from 'styled-components';
 import {useEffect, useState} from 'react';

--- a/src/components/GenerateChat/GenerateChat.tsx
+++ b/src/components/GenerateChat/GenerateChat.tsx
@@ -53,7 +53,7 @@ const GenerateChat = (props: ModalProps) => {
     }
 
     if (userData[1].length < 2) {
-      // 자신을 포함 3명 이하 예외 조건 처리
+      // 자신을 포함 2명 이하 예외 조건 처리
       let temp: InputStates = [...inputStates];
       temp[1].state = 'error';
       setInputStates(temp);
@@ -104,7 +104,7 @@ const GenerateChat = (props: ModalProps) => {
               ></SearchBar>
             </StyledDiv>
             <div>
-              <StyledLabel>선택된 사용자 (3명 이상)</StyledLabel>
+              <StyledLabel>선택된 사용자 (2명 이상 선택)</StyledLabel>
               <UserCells
                 typed="checked"
                 allocatedData={userData[1]}

--- a/src/components/HeaderLayout/TabButton/TabButtons.tsx
+++ b/src/components/HeaderLayout/TabButton/TabButtons.tsx
@@ -6,11 +6,11 @@ import {theme} from '../../../styles/Theme';
 
 const TabButton = () => {
   const [tabContents, setTabContents] = useState<TabProps[]>([
-    {label: '가나다 순', isSelected: true},
-    {label: '최근 채팅 순', isSelected: false},
-    {label: '사람 많은 순', isSelected: false},
-    {label: '새로운 순', isSelected: false},
-    {label: '홀로 있는 방', isSelected: false},
+    {label: '가나다 순', selected: true},
+    {label: '최근 채팅 순', selected: false},
+    {label: '사람 많은 순', selected: false},
+    {label: '새로운 순', selected: false},
+    {label: '홀로 있는 방', selected: false},
   ]);
 
   return (
@@ -18,7 +18,7 @@ const TabButton = () => {
       <StyledLabel>정렬</StyledLabel>
       <StyledTabContainer>
         {tabContents.map(contents => (
-          <TabEl onClick={setTabContents} tabContents={tabContents} contents={contents}></TabEl>
+          <TabEl key={contents.label} onClick={setTabContents} tabContents={tabContents} contents={contents}></TabEl>
         ))}
       </StyledTabContainer>
     </StyledDiv>

--- a/src/components/HeaderLayout/TabButton/TabEl.tsx
+++ b/src/components/HeaderLayout/TabButton/TabEl.tsx
@@ -17,9 +17,9 @@ const TabEl = (props: Props) => {
     let copied = props.tabContents.slice();
     copied.forEach(el => {
       if (el.label === targetLabel) {
-        el.isSelected = true;
+        el.selected = true;
       } else {
-        el.isSelected = false;
+        el.selected = false;
       }
     });
 
@@ -29,7 +29,7 @@ const TabEl = (props: Props) => {
   return (
     <StyledTabEl //
       onClick={clickHandler}
-      isSelected={props.contents.isSelected}
+      selected={props.contents.selected}
     >
       {props.contents.label}
     </StyledTabEl>
@@ -38,12 +38,12 @@ const TabEl = (props: Props) => {
 
 export default TabEl;
 
-const StyledTabEl = styled.button<{isSelected?: boolean}>`
+const StyledTabEl = styled.button<{selected?: boolean}>`
   width: 84px;
   height: 26px;
 
-  background-color: ${props => (props.isSelected ? theme.colors.blue700 : '')};
-  color: ${props => (props.isSelected ? theme.colors.white : theme.colors.gray900)};
+  background-color: ${props => (props.selected ? theme.colors.blue700 : '')};
+  color: ${props => (props.selected ? theme.colors.white : theme.colors.gray900)};
   border-radius: 4px;
   white-space: nowrap;
   padding: 0;

--- a/src/components/HeaderLayout/TabButton/TabProps.ts
+++ b/src/components/HeaderLayout/TabButton/TabProps.ts
@@ -1,6 +1,6 @@
 interface TabProps {
   label: string;
-  isSelected: boolean;
+  selected: boolean;
 }
 
 export default TabProps;


### PR DESCRIPTION
close https://github.com/turkey-kim/8lack/issues/41
## 작업내용

- 모든 API보기로 교체
<br>

## 주요 변경점 
- 모든 API보기로 교체
이제 모든 사용자가 같은 화면을 보게 됩니다.

<img width="1440" alt="image" src="https://github.com/turkey-kim/8lack/assets/126222848/ca9f07e1-889f-4059-a7f8-5d260034dab3">

<br>

## 유의할 점 (optional)
<br>

## To Reviewers (optional)
- 내 채팅방 보기가 적용됐을 때 제 환경에서 새로 만든게 안 보이는 현상은 여전했습니다ㅠㅠ
어쩌면 한 명이 최대로 만들 수 있는 방 개수라도 정해져 있는것인지 뭔지 모르겠군요.
- 그러나 모든 채팅방 보기로 바꾸니 제가 만들었던 것도 포함해서 다 보이긴 합니다.

- 그룹채팅방 정렬, 검색 로직 (민서님 작업 참고)
- 방 참여하기
- 채팅방 참여자 목록
- 이미 들어간 채팅방 참여중으로 바꾸기
(모든 방에 참여해버리면 메인페이지가 휑해질까봐.. 그리고 참여중인걸 보여주는 편이 더 서비스 이용하기 쉬울것 같습니다.)