### PR TITLE
[#10] 사이드바 - 그룹 채팅 기능 구현

### DIFF
--- a/src/api/myChatRoom.ts
+++ b/src/api/myChatRoom.ts
@@ -1,6 +1,6 @@
 import axios from 'axios';
 import {authHeaders} from './auth';
-import {SERVER_URL} from '../constant/constant';
+import {SERVER_URL} from 'constant/constant';
 
 export const myChatRoom = async () => {
   try {

--- a/src/components/GroupChat/GroupChat.tsx
+++ b/src/components/GroupChat/GroupChat.tsx
@@ -1,45 +1,25 @@
-import React from 'react';
-import styled from 'styled-components';
-import {theme} from '../../styles/Theme';
 import {format, register} from 'timeago.js';
 import koLocale from 'timeago.js/lib/lang/ko';
-
+import {Props} from 'types/chatroom.types';
+import {
+  StyledContainer,
+  StyledSubContainer,
+  StyledImg,
+  StyledTextContainer,
+  StyledTitle,
+  StyledText,
+  StyledDate,
+  StyledLatestMessage,
+  StyledDiv,
+} from 'components/PrivateChat/PrivateChat';
 register('ko', koLocale);
 
-export interface Chat {
-  id: string;
-  name: string;
-  users: User[]; // 속한 유저 id
-  isPrivate: boolean;
-  latestMessage: Message | null;
-  updatedAt: Date;
-}
-
-interface User {
-  id: string;
-  name: string;
-  picture: string;
-}
-
-interface Message {
-  id: string;
-  text: string;
-  userId: string;
-  createdAt: Date;
-}
-
-interface Props {
-  key: string;
-  data: Chat;
-}
-
 export default function GroupChat(props: Props) {
-  // const [privateRooms, setPrivateRooms] = useState<Chat[]>(dummyPrivateRooms);
   const {id, name, updatedAt, latestMessage, users} = props.data;
   return (
     <StyledContainer>
       <StyledSubContainer>
-        <StyledImg src={users[1].picture} alt="사용자 프로필 이미지" />
+        <StyledImg src={users[0].picture} alt="그룹 채팅방 이미지" />
         <StyledTextContainer>
           <StyledTitle>{name}</StyledTitle>
           <StyledText>{latestMessage?.text}</StyledText>
@@ -52,62 +32,3 @@ export default function GroupChat(props: Props) {
     </StyledContainer>
   );
 }
-
-const StyledContainer = styled.li`
-  display: flex;
-  justify-content: space-around;
-  width: 100%;
-  padding: 1rem 0;
-  background-color: white;
-  cursor: pointer;
-  transition: all 0.3s ease-out;
-  &:hover {
-    background-color: ${theme.colors.blue100};
-  }
-`;
-
-const StyledSubContainer = styled.div`
-  display: flex;
-  gap: 1rem;
-`;
-
-const StyledImg = styled.img`
-  width: 4rem;
-  height: 4rem;
-`;
-
-const StyledTextContainer = styled.div`
-  display: flex;
-  flex-direction: column;
-  justify-content: space-around;
-  padding: 0.5rem;
-`;
-
-const StyledTitle = styled.h2`
-  font-size: ${props => props.theme.fonts.subtitle5.fontSize};
-`;
-
-const StyledText = styled.p`
-  font-size: ${props => props.theme.fonts.body2.fontSize};
-`;
-
-const StyledDiv = styled.div`
-  display: flex;
-  flex-direction: column;
-  justify-content: space-between;
-  align-items: flex-end;
-`;
-
-const StyledDate = styled.p`
-  margin-top: 0.5rem;
-  font-size: ${props => props.theme.fonts.body2.fontSize};
-  color: ${props => props.theme.colors.gray600};
-`;
-
-const StyledLatestMessage = styled.div`
-  margin-bottom: 0.625rem;
-  width: 0.875rem;
-  height: 0.875rem;
-  border-radius: 50%;
-  background-color: ${theme.colors.pink800};
-`;

--- a/src/components/GroupChat/GroupChats.tsx
+++ b/src/components/GroupChat/GroupChats.tsx
@@ -1,13 +1,31 @@
-import React from 'react';
-import {dummyPrivateRooms} from '../PrivateChat/dummyPrivateRooms';
+import React, {useEffect, useState} from 'react';
 import GroupChat from './GroupChat';
+import {myChatRoom} from 'api/myChatRoom';
+import {StyledContainer} from 'components/PrivateChat/PrivateChats';
+import {Chat} from 'types/chatroom.types';
 
 export default function GroupChats() {
+  const [myGroupChat, setMyGroupChat] = useState<Chat[]>([]);
+  const [sortedChat, setSortedChat] = useState<Chat[]>([]);
+
+  useEffect(() => {
+    myChatRoom().then(room => {
+      setMyGroupChat(room.chats);
+    });
+  }, []);
+
+  useEffect(() => {
+    const sorted = [...myGroupChat]
+      .filter(room => !room.isPrivate)
+      .sort((a, b) => new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime());
+    setSortedChat(sorted);
+  }, [myGroupChat]);
+
   return (
-    <ul>
-      {dummyPrivateRooms.map(room => {
-        return !room.isPrivate && <GroupChat key={room.id} data={room} />;
+    <StyledContainer>
+      {sortedChat.map(room => {
+        return <GroupChat key={room.id} data={room} />;
       })}
-    </ul>
+    </StyledContainer>
   );
 }

--- a/src/components/PrivateChat/PrivateChat.tsx
+++ b/src/components/PrivateChat/PrivateChat.tsx
@@ -1,10 +1,7 @@
-import {useState, useEffect} from 'react';
 import styled from 'styled-components';
 import {theme} from '../../styles/Theme';
-import {authCheck} from '../../api/auth';
 import {format, register} from 'timeago.js';
 import koLocale from 'timeago.js/lib/lang/ko';
-import {myChatRoom} from 'api/myChatRoom';
 
 register('ko', koLocale);
 
@@ -55,7 +52,7 @@ export default function PrivateChat(props: Props) {
   );
 }
 
-const StyledContainer = styled.li`
+export const StyledContainer = styled.li`
   display: flex;
   justify-content: space-around;
   width: 100%;
@@ -68,45 +65,46 @@ const StyledContainer = styled.li`
   }
 `;
 
-const StyledSubContainer = styled.div`
+export const StyledSubContainer = styled.div`
   display: flex;
   gap: 1rem;
 `;
 
-const StyledImg = styled.img`
+export const StyledImg = styled.img`
   width: 4rem;
   height: 4rem;
 `;
 
-const StyledTextContainer = styled.div`
+export const StyledTextContainer = styled.div`
+  width: 11.25rem;
   display: flex;
   flex-direction: column;
   justify-content: space-around;
   padding: 0.5rem;
 `;
 
-const StyledTitle = styled.h2`
+export const StyledTitle = styled.h2`
   font-size: ${props => props.theme.fonts.subtitle5.fontSize};
 `;
 
-const StyledText = styled.p`
+export const StyledText = styled.p`
   font-size: ${props => props.theme.fonts.body2.fontSize};
 `;
 
-const StyledDiv = styled.div`
+export const StyledDiv = styled.div`
   display: flex;
   flex-direction: column;
   justify-content: space-between;
   align-items: flex-end;
 `;
 
-const StyledDate = styled.p`
+export const StyledDate = styled.p`
   margin-top: 0.5rem;
   font-size: ${props => props.theme.fonts.body2.fontSize};
   color: ${props => props.theme.colors.gray600};
 `;
 
-const StyledLatestMessage = styled.div`
+export const StyledLatestMessage = styled.div`
   margin-bottom: 0.625rem;
   width: 0.875rem;
   height: 0.875rem;

--- a/src/components/PrivateChat/PrivateChats.tsx
+++ b/src/components/PrivateChat/PrivateChats.tsx
@@ -1,6 +1,8 @@
 import {useEffect, useState} from 'react';
 import PrivateChat, {Chat} from './PrivateChat';
 import {dummyPrivateRooms} from './dummyPrivateRooms';
+import styled from 'styled-components';
+import {theme} from '../../styles/Theme';
 
 export default function PrivateChats() {
   const [sortedChat, setSortedChat] = useState<Chat[]>([]);
@@ -11,11 +13,27 @@ export default function PrivateChats() {
       .sort((a, b) => b.updatedAt.getTime() - a.updatedAt.getTime());
     setSortedChat(sorted);
   }, []);
+
   return (
-    <ul>
+    <StyledContainer>
       {sortedChat.map(room => (
         <PrivateChat key={room.id} data={room} />
       ))}
-    </ul>
+    </StyledContainer>
   );
 }
+
+export const StyledContainer = styled.ul`
+  height: 34rem;
+  overflow-y: auto;
+  &::-webkit-scrollbar {
+    width: 0.5rem;
+    height: 0.5rem;
+    border-radius: 6px;
+    background: ${theme.colors.gray100};
+  }
+  &::-webkit-scrollbar-thumb {
+    background: ${theme.colors.gray300};
+    border-radius: 6px;
+  }
+`;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -12,7 +12,7 @@ import NotFound from './pages/NotFound';
 import Users from './pages/Users';
 import SignIn from './pages/SignIn';
 import SignUp from 'pages/SignUp';
-import ChatRoom from 'pages/ChatRoom';
+import ChatRoom from 'pages/ChatRoom/index';
 import GroupChatList from './pages/GroupChatList';
 import Modal from 'react-modal';
 

--- a/src/types/chatroom.types.ts
+++ b/src/types/chatroom.types.ts
@@ -6,6 +6,15 @@ export interface ChatRoom {
   updatedAt: Date;
 }
 
+export interface Chat {
+  id: string;
+  name: string;
+  users: User[]; // 속한 유저 id
+  isPrivate: boolean;
+  latestMessage: Message | null;
+  updatedAt: Date;
+}
+
 export interface User {
   id: string;
   name: string;
@@ -35,4 +44,9 @@ export interface NewUser {
 export interface leaveUser {
   users: string[]; // 참여자들 id
   leaver: string; // 나간 사용자 id
+}
+
+export interface Props {
+  key: string;
+  data: Chat;
 }


### PR DESCRIPTION
close #10 

## 작업내용
- 그룹채팅방 api 연결
- `lastestMessage` 를 받은 시간 순서대로 그룹 채팅방 정렬
- 공통으로 겹치는 코드 정리 
- `chatroom.types.ts` 에 `Chat`, `Props` interface 추가
<br>

## 주요 변경점 

- 내가 속해있는 그룹채팅방 시간순으로 정렬
![image](https://github.com/turkey-kim/8lack/assets/83440978/26baa6ef-f103-4ebf-9181-65bc29b7c103)
    - height 크기를 넘어가게 되면 스크롤 표시
<br>

## 유의할 점 (optional)
- 최신메세지를 계속 받아오는 로직은 추후에 구현 예정입니다!
- 지금 보니까 사이드바 디자인이 좀 밀리네욥.. 추후에 함께 수정해서 올리겠습니다! 🥲🥲
<br>

## To Reviewers (optional)
- 그룹채팅방에 보일 이미지를 어떻게 설정하면 좋을지 의견 남겨주시면 감사하겠습니다! 일단 지금은 첫번째 유저의 프로필을 가져왔습니당 
