### PR TITLE
[#49] 그룹 채팅방 리스트에서 그룹 채팅방 입장 가능 및 입장한 그룹 채팅방은 숨김 처리

### DIFF
--- a/src/api/wholeChatRoom.ts
+++ b/src/api/wholeChatRoom.ts
@@ -2,7 +2,7 @@ import axios from 'axios';
 import {authHeaders} from './auth';
 import {SERVER_URL} from '../constant/constant';
 
-export const allChatRoom = async () => {
+export const wholeChatRoom = async () => {
   try {
     const response = await axios.get(`${SERVER_URL}/chat/all`, {headers: authHeaders()});
     return response.data;

--- a/src/pages/GroupChatList/ChatRoomsList/ChatRoomEl.tsx
+++ b/src/pages/GroupChatList/ChatRoomsList/ChatRoomEl.tsx
@@ -41,7 +41,7 @@ const ChatRoomEl = (props: Props) => {
 
     setInterval(() => {
       calcTime();
-    }, 30000);
+    }, 30000); // 시간은 30초 마다 갱신
   }, [props.data.updatedAt]);
 
   const joinHandler = () => {

--- a/src/pages/GroupChatList/ChatRoomsList/ChatRoomEl.tsx
+++ b/src/pages/GroupChatList/ChatRoomsList/ChatRoomEl.tsx
@@ -41,13 +41,13 @@ const ChatRoomEl = (props: Props) => {
 
     setInterval(() => {
       calcTime();
-    }, 30000); // 시간은 30초 마다 갱신
+    }, 30000); // 마지막 채팅 시간은 30초 마다 갱신
   }, [props.data.updatedAt]);
 
   const joinHandler = () => {
     const ID = props.data.id;
     const NAME = props.data.name;
-    const confirm = window.confirm(`${NAME} 방에 참여하시겠어요?`);
+    const confirm = window.confirm(`${NAME} 방에 들어가시겠어요?`);
     if (confirm) {
       handleChatParticipate(ID).then(res => navigate(`/chat/${ID}`));
     }

--- a/src/pages/GroupChatList/ChatRoomsList/ChatRoomEl.tsx
+++ b/src/pages/GroupChatList/ChatRoomsList/ChatRoomEl.tsx
@@ -1,5 +1,7 @@
+import {handleChatParticipate} from 'api/chat';
 import {useEffect, useState} from 'react';
 import {FaAngleDown} from 'react-icons/fa';
+import {useNavigate} from 'react-router';
 import styled from 'styled-components';
 import {theme} from 'styles/Theme';
 
@@ -23,6 +25,7 @@ interface Props {
 
 const ChatRoomEl = (props: Props) => {
   const [time, setTime] = useState<string>('');
+  const navigate = useNavigate();
 
   useEffect(() => {
     const calcTime = () => {
@@ -41,6 +44,15 @@ const ChatRoomEl = (props: Props) => {
     }, 30000);
   }, [props.data.updatedAt]);
 
+  const joinHandler = () => {
+    const ID = props.data.id;
+    const NAME = props.data.name;
+    const confirm = window.confirm(`${NAME} 방에 참여하시겠어요?`);
+    if (confirm) {
+      handleChatParticipate(ID).then(res => navigate(`/chat/${ID}`));
+    }
+  };
+
   return (
     <StyledContainer>
       <StyledInner>
@@ -57,7 +69,7 @@ const ChatRoomEl = (props: Props) => {
             <span>참여 중인 사용자</span>
             <StyledAngleDown></StyledAngleDown>
           </StyledMemberListBtn>
-          <StyledEnterButton>들어가기</StyledEnterButton>
+          <StyledEnterButton onClick={joinHandler}>들어가기</StyledEnterButton>
         </StyledEnterance>
       </StyledInner>
     </StyledContainer>

--- a/src/pages/GroupChatList/ChatRoomsList/ChatRoomsList.tsx
+++ b/src/pages/GroupChatList/ChatRoomsList/ChatRoomsList.tsx
@@ -1,4 +1,4 @@
-import {allChatRoom} from 'api/AllChatRoom';
+import {allChatRoom} from 'api/allChatRoom';
 import ChatRoomEl from './ChatRoomEl';
 import styled from 'styled-components';
 import {useEffect, useState} from 'react';

--- a/src/pages/GroupChatList/ChatRoomsList/ChatRoomsList.tsx
+++ b/src/pages/GroupChatList/ChatRoomsList/ChatRoomsList.tsx
@@ -1,4 +1,5 @@
 import {allChatRoom} from 'api/allChatRoom';
+import {myChatRoom} from 'api/myChatRoom';
 import ChatRoomEl from './ChatRoomEl';
 import styled from 'styled-components';
 import {useEffect, useState} from 'react';
@@ -16,9 +17,31 @@ const ChatLists = () => {
   const [chatRoomsList, setChatRoomsList] = useState<Chat[]>([]);
 
   useEffect(() => {
-    allChatRoom().then(res => {
-      setChatRoomsList(res.chats);
-    });
+    const fetchData = async () => {
+      try {
+        const allChat = await allChatRoom();
+        const myChat = await myChatRoom();
+        const refinedAllChat: Chat[] = allChat.chats;
+        const refinedMyChat: Chat[] = myChat.chats;
+        // console.log(refinedAllChat);
+        console.log(refinedMyChat, 'MyChatList');
+
+        const filtered = refinedAllChat.filter(allChat => {
+          for (let i = 0; i < refinedMyChat.length; i++) {
+            if (allChat.id === refinedMyChat[i].id) {
+              console.log(allChat.id, 'allChat id', refinedMyChat[i].id, 'refinedMyId');
+              return false;
+            }
+          }
+          return true;
+        });
+
+        setChatRoomsList(filtered);
+      } catch (error) {
+        console.error(error);
+      }
+    };
+    fetchData();
   }, []);
 
   return (

--- a/src/pages/GroupChatList/ChatRoomsList/ChatRoomsList.tsx
+++ b/src/pages/GroupChatList/ChatRoomsList/ChatRoomsList.tsx
@@ -1,4 +1,4 @@
-import {allChatRoom} from 'api/allChatRoom';
+import {wholeChatRoom} from 'api/wholeChatRoom';
 import {myChatRoom} from 'api/myChatRoom';
 import ChatRoomEl from './ChatRoomEl';
 import styled from 'styled-components';
@@ -19,12 +19,10 @@ const ChatLists = () => {
   useEffect(() => {
     const fetchData = async () => {
       try {
-        const allChat = await allChatRoom();
+        const allChat = await wholeChatRoom();
         const myChat = await myChatRoom();
         const refinedAllChat: Chat[] = allChat.chats;
         const refinedMyChat: Chat[] = myChat.chats;
-        // console.log(refinedAllChat);
-        console.log(refinedMyChat, 'MyChatList');
 
         const filtered = refinedAllChat.filter(allChat => {
           for (let i = 0; i < refinedMyChat.length; i++) {

--- a/src/pages/GroupChatList/HeaderLayout/GenerateChat/GenerateChat.tsx
+++ b/src/pages/GroupChatList/HeaderLayout/GenerateChat/GenerateChat.tsx
@@ -87,7 +87,7 @@ const GenerateChat = (props: ModalProps) => {
             <SearchBar content="사용자를 검색해보세요" height="40" onSearchName={setSearchUserData}></SearchBar>
             <UserCells
               height="312px"
-              marginTop="8px"
+              $marginTop="8px"
               typed=""
               allocatedData={userData[0]}
               subData={userData[1]}
@@ -99,7 +99,7 @@ const GenerateChat = (props: ModalProps) => {
             <StyledDiv>
               <StyledLabel>그룹 채팅방 제목 (필수)</StyledLabel>
               <SearchBar
-                inputState={inputStates[0].state}
+                $inputState={inputStates[0].state}
                 onChangeName={setChatName}
                 content="그룹 채팅방 이름을 적어주세요"
                 height="40"
@@ -113,7 +113,7 @@ const GenerateChat = (props: ModalProps) => {
                 subData={userData[0]}
                 onToggleUser={setUserData}
                 height="275px"
-                inputState={inputStates[1].state}
+                $inputState={inputStates[1].state}
               ></UserCells>
             </div>
           </StyledUnit>

--- a/src/pages/GroupChatList/HeaderLayout/GenerateChat/UserCell.tsx
+++ b/src/pages/GroupChatList/HeaderLayout/GenerateChat/UserCell.tsx
@@ -11,7 +11,7 @@ interface UserCellProps {
 }
 
 const UserCell = (props: UserCellProps) => {
-  const isCheckedHandler = (e: React.MouseEvent<HTMLInputElement>) => {
+  const isCheckedHandler: React.ChangeEventHandler = e => {
     const newAllocUser = props.allocatedData.slice().filter(arg => arg.id !== props.user.id);
     const newSubUser = props.subData.slice();
     newSubUser.push(props.user);
@@ -29,7 +29,7 @@ const UserCell = (props: UserCellProps) => {
         <StyledPrfImg src={props.user.picture} />
         <StyledPrfName>{props.user.name}</StyledPrfName>
       </StyledPrf>
-      <input type="checkbox" onClick={isCheckedHandler} checked={props.typed ? true : false} />
+      <input type="checkbox" onChange={isCheckedHandler} checked={props.typed ? true : false} />
     </StyledCellContainer>
   );
 };

--- a/src/pages/GroupChatList/HeaderLayout/GenerateChat/UserCells.tsx
+++ b/src/pages/GroupChatList/HeaderLayout/GenerateChat/UserCells.tsx
@@ -7,8 +7,8 @@ import {useEffect, useState} from 'react';
 interface UserCellsProps {
   typed: string;
   height: string;
-  marginTop?: string;
-  inputState?: string;
+  $marginTop?: string;
+  $inputState?: string;
   filteredUserData?: User[];
   allocatedData: User[];
   subData: User[];
@@ -36,8 +36,8 @@ const UserCells = (props: UserCellsProps) => {
   return (
     <StyledUserContainer //
       height={props.height}
-      marginTop={props.marginTop}
-      inputState={props.inputState}
+      $marginTop={props.$marginTop}
+      $inputState={props.$inputState}
     >
       {searchUserData && filteredUserData
         ? filteredUserData.map(userData => (
@@ -66,17 +66,17 @@ const UserCells = (props: UserCellsProps) => {
 
 export default UserCells;
 
-const StyledUserContainer = styled.div<Pick<UserCellsProps, 'height' | 'marginTop' | 'inputState'>>`
+const StyledUserContainer = styled.div<Pick<UserCellsProps, 'height' | '$marginTop' | '$inputState'>>`
   width: 100%;
   height: ${props => props.height};
-  margin-top: ${props => (props.marginTop ? props.marginTop : '')};
+  margin-top: ${props => (props.$marginTop ? props.$marginTop : '')};
 
   background-color: ${theme.colors.gray100};
   border: 1px solid
     ${props => {
-      if (props.inputState === 'error') {
+      if (props.$inputState === 'error') {
         return theme.colors.error;
-      } else if (props.inputState === 'success') {
+      } else if (props.$inputState === 'success') {
         return theme.colors.success;
       } else {
         return theme.colors.gray400;

--- a/src/pages/GroupChatList/HeaderLayout/SearchBar.tsx
+++ b/src/pages/GroupChatList/HeaderLayout/SearchBar.tsx
@@ -5,7 +5,7 @@ import {theme} from '../../../styles/Theme';
 interface SearchBarProps {
   height: string;
   content: string;
-  inputState?: string;
+  $inputState?: string;
   onChangeName?: React.Dispatch<React.SetStateAction<string>>;
   onSearchName?: React.Dispatch<React.SetStateAction<string>>;
 }
@@ -26,7 +26,7 @@ const SearchBar = (props: SearchBarProps) => {
     <StyledInputContainer>
       <StyledSearchIcon></StyledSearchIcon>
       <StyledSearchBar
-        inputState={props.inputState}
+        $inputState={props.$inputState}
         onChange={nameHander}
         height={props.height}
         placeholder={props.content}
@@ -51,10 +51,10 @@ const StyledSearchIcon = styled(MdSearch)`
   color: ${theme.colors.gray500};
 `;
 
-const StyledSearchBar = styled.input<Pick<SearchBarProps, 'height' | 'inputState'>>`
+const StyledSearchBar = styled.input<Pick<SearchBarProps, 'height' | '$inputState'>>`
   width: 100%;
   height: ${props => props.height + 'px'};
   padding-left: 36px;
-  border: 1px solid ${props => (props.inputState === 'error' ? theme.colors.error : props.theme.colors.gray500)};
+  border: 1px solid ${props => (props.$inputState === 'error' ? theme.colors.error : props.theme.colors.gray500)};
   border-radius: 4px;
 `;


### PR DESCRIPTION
close https://github.com/turkey-kim/8lack/issues/49

## 작업내용

- 그룹채팅방 리스트에서 그룹 채팅방에 입장할 수 있습니다.
- 그룹채팅방 리스트에서 이미 입장한 그룹 채팅방은 숨김 처리됩니다.
- 그룹채팅방 생성 모달에 접속할 때도 warning 뜨던 것도 다 해소했습니다.
<br>

## 주요 변경점 

- 그룹채팅방 리스트에서 그룹 채팅방에 입장할 수 있습니다.
<img width="1440" alt="image" src="https://github.com/turkey-kim/8lack/assets/126222848/82b5354a-1ddd-4157-9997-f4b0e126c244">

<img width="1438" alt="image" src="https://github.com/turkey-kim/8lack/assets/126222848/29bea52e-fd14-4052-b445-b12f336c6bc2">

- 들어간 채팅방은 메인 페이지에서 나오지 않습니다.
메인페이지에 처음 접속하면 allChatRoom과 myChatRoom를 서버에서 받아와 비교해서
myChatRoom리스트에 있는 것들과 id가 겹치는 것은 filter메소드로 걸렀습니다.

<img width="1156" alt="image" src="https://github.com/turkey-kim/8lack/assets/126222848/430a32b1-fe4f-4bdb-bc31-6e4224ceb926">


<br>

## To Reviewers (optional)

- 리뷰어에게 부탁할 내용(ex.~부분 도움 부탁합니다, ~부분 한 번 더 검토 부탁드려요) 이 있다면 적어주세요.
