### PR TITLE
feat: 생성 모달에서 즐겨찾기 표출, 생성 모달에도 로딩 컴포넌트 적용,  검색 결과 없음 컴포넌트 추가, 그룹 채팅방 …

### DIFF
--- a/src/components/GenerateModal/GenerateModal.tsx
+++ b/src/components/GenerateModal/GenerateModal.tsx
@@ -30,25 +30,30 @@ const GenerateModal = (props: ModalProps) => {
   // [선택가능한 유저 배열, 선택된유저 배열]
   const [searchUserData, setSearchUserData] = useState('');
   // 검색어
-
   const [chatName, setChatName] = useState<string>('');
   // 방이름
-
   const [inputStates, setInputStates] = useState<InputStates>([
     {name: 'chatName', state: 'default'},
     {name: 'pickedUser', state: 'default'},
   ]);
+  // 에러 상태
+  const [isLoading, setIsLoading] = useState<boolean>(false);
+  // 로딩 중 (비동기 요청 중)
 
   const navigate = useNavigate();
   const {chatId} = useParams();
   const myInfo = useRecoilValue(userInformation);
 
   useEffect(() => {
+    setIsLoading(true);
     // 사용자 불러오기
-    getUsers().then(res => {
-      const filtered = (res as User[]).slice().filter(val => val.id !== myInfo.id);
-      setUserData([filtered, []]);
-    });
+    getUsers()
+      .then(res => {
+        const filtered = (res as User[]).slice().filter(val => val.id !== myInfo.id);
+        setUserData([filtered, []]);
+      })
+      .catch(err => console.log(err))
+      .finally(() => setIsLoading(false));
   }, [myInfo.id]);
 
   const modalCloseHandler = () => {
@@ -120,6 +125,7 @@ const GenerateModal = (props: ModalProps) => {
             <StyledLabel>{props.label1}</StyledLabel>
             <SearchBar content="사용자를 검색해보세요" height="40" onSearchName={setSearchUserData}></SearchBar>
             <UserCells
+              isLoading={isLoading}
               height="312px"
               $marginTop="8px"
               typed=""

--- a/src/components/GenerateModal/UserCell.tsx
+++ b/src/components/GenerateModal/UserCell.tsx
@@ -1,6 +1,7 @@
 import styled from 'styled-components';
 import {theme} from 'styles/Theme';
 import {User} from 'types/chatroom.types';
+import {FaStar} from 'react-icons/fa';
 
 interface UserCellProps {
   typed: string;
@@ -28,6 +29,7 @@ const UserCell = (props: UserCellProps) => {
       <StyledPrf>
         <StyledPrfImg src={props.user.picture} />
         <StyledPrfName>{props.user.name}</StyledPrfName>
+        {localStorage.getItem(`isChecked-${props.user.id}`) === 'true' && <StyledStar></StyledStar>}
       </StyledPrf>
       <input type="checkbox" onChange={isCheckedHandler} checked={props.typed ? true : false} />
     </StyledCellContainer>
@@ -61,4 +63,11 @@ const StyledPrfName = styled.span`
   font-size: ${theme.fonts.body2.fontSize};
   font-weight: ${theme.fonts.subtitle5.fontWeight};
   line-height: ${theme.fonts.body2.lineHeight};
+`;
+
+const StyledStar = styled(FaStar)`
+  font-size: 16px;
+  color: ${theme.colors.blue700};
+  position: relative;
+  top: -1px;
 `;

--- a/src/components/GenerateModal/UserCells.tsx
+++ b/src/components/GenerateModal/UserCells.tsx
@@ -3,6 +3,7 @@ import {theme} from 'styles/Theme';
 import UserCell from './UserCell';
 import {User} from 'types/chatroom.types';
 import {useEffect, useState} from 'react';
+import LoadingCircle from 'components/LoadingCircle/LoadingCircle';
 
 interface UserCellsProps {
   typed: string;
@@ -14,11 +15,13 @@ interface UserCellsProps {
   subData: User[];
   onToggleUser: React.Dispatch<React.SetStateAction<[User[], User[]]>>;
   searchUserData?: string;
+  isLoading?: boolean;
 }
 
 const UserCells = (props: UserCellsProps) => {
   const [filteredUserData, setFilteredUserData] = useState<User[]>([]);
-  const {searchUserData, allocatedData} = props;
+
+  const {searchUserData, allocatedData, isLoading} = props;
 
   useEffect(() => {
     filterUsers();
@@ -39,7 +42,8 @@ const UserCells = (props: UserCellsProps) => {
       $marginTop={props.$marginTop}
       $inputState={props.$inputState}
     >
-      {searchUserData && filteredUserData
+      {isLoading && <LoadingCircle width="200px" height="300px"></LoadingCircle>}
+      {!isLoading && searchUserData
         ? filteredUserData.map(userData => (
             <UserCell
               typed={props.typed}

--- a/src/components/NoSearchResult/index.tsx
+++ b/src/components/NoSearchResult/index.tsx
@@ -1,0 +1,42 @@
+import styled from 'styled-components';
+import {Player} from '@lottiefiles/react-lottie-player';
+import {theme} from 'styles/Theme';
+
+interface NoSearchResultProps {
+  width?: string;
+  height?: string;
+  text: string;
+}
+
+const NoSearchResult = ({width = '250px', height = '250px', text}: NoSearchResultProps) => {
+  return (
+    <StyledContainer>
+      <Player
+        autoplay
+        loop
+        src="https://lottie.host/ec5e6378-d6c3-45fa-841e-935cb220561c/ZsxLuOHOZj.json"
+        style={{height: height, width: width}}
+      ></Player>
+      <StyledDiv>{text}</StyledDiv>
+    </StyledContainer>
+  );
+};
+
+export default NoSearchResult;
+
+const StyledContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  width: 100%;
+  height: 100%;
+`;
+
+const StyledDiv = styled.div`
+  font-size: ${theme.fonts.subtitle5.fontSize};
+  font-weight: ${theme.fonts.subtitle5.fontWeight};
+  line-height: ${theme.fonts.subtitle5.lineHeight};
+
+  color: ${theme.colors.gray700};
+`;

--- a/src/pages/GroupChatList/GroupChatRoomsLayout/GroupChatParticipant.tsx
+++ b/src/pages/GroupChatList/GroupChatRoomsLayout/GroupChatParticipant.tsx
@@ -1,0 +1,99 @@
+import {useState} from 'react';
+import styled from 'styled-components';
+import {theme} from 'styles/Theme';
+import {FaAngleDown} from 'react-icons/fa';
+import {User} from 'types/chatroom.types';
+
+interface GroupChatParticipantProps {
+  children: string;
+  users: User[];
+}
+
+const GroupChatParticipant = (props: GroupChatParticipantProps) => {
+  const [isOpen, setIsOpen] = useState<boolean>(false);
+  const toggleHandler = () => {
+    setIsOpen(prev => !prev);
+  };
+  return (
+    <StyledContainer>
+      <StyledMemberListBtn onFocus={toggleHandler} onBlur={toggleHandler}>
+        {props.children}
+        <StyledAngleDown></StyledAngleDown>
+      </StyledMemberListBtn>
+      {isOpen && (
+        <StyledUl>
+          {props.users.map(user => (
+            <StyledLi>{user.username}</StyledLi>
+          ))}
+        </StyledUl>
+      )}
+    </StyledContainer>
+  );
+};
+
+export default GroupChatParticipant;
+
+const StyledContainer = styled.div`
+  position: relative;
+`;
+
+const StyledMemberListBtn = styled.button`
+  font-size: ${theme.fonts.body1.fontSize};
+  font-weight: ${theme.fonts.body1.fontWeight};
+  line-height: ${theme.fonts.body1.lineHeight};
+
+  color: ${theme.colors.gray700};
+  display: flex;
+  gap: 0.125rem;
+  align-items: center;
+  border-radius: 0.25rem;
+
+  transition: 0.5s;
+
+  &:hover {
+    background-color: ${theme.colors.blue200};
+  }
+
+  &:focus {
+    background-color: ${theme.colors.blue200};
+  }
+`;
+
+const StyledAngleDown = styled(FaAngleDown)`
+  color: ${theme.colors.gray600};
+`;
+
+const StyledUl = styled.ul`
+  position: absolute;
+  z-index: 5;
+
+  display: flex;
+  flex-direction: column;
+
+  width: 100%;
+  max-height: 128px;
+  background-color: ${theme.colors.white};
+
+  border: 0.063rem solid ${theme.colors.blue500};
+  border-radius: 0.25rem;
+  overflow-y: scroll;
+  overflow-x: hidden;
+  box-shadow: ${theme.shadows.shadow1.shadow};
+`;
+
+const StyledLi = styled.li`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+
+  background-color: ${theme.colors.white};
+  width: 100%;
+  height: 2rem;
+  border-radius: 0.25rem;
+
+  font-size: ${theme.fonts.body2.fontSize};
+  font-weight: ${theme.fonts.body2.fontWeight};
+  line-height: ${theme.fonts.body2.lineHeight};
+
+  color: ${theme.colors.gray700};
+`;

--- a/src/pages/GroupChatList/GroupChatRoomsLayout/GroupChatRoomEl.tsx
+++ b/src/pages/GroupChatList/GroupChatRoomsLayout/GroupChatRoomEl.tsx
@@ -1,11 +1,10 @@
+import GroupChatParticipant from './GroupChatParticipant';
 import {participateChatRoom} from 'api/myChatRoom';
 import {useEffect, useState} from 'react';
-import {FaAngleDown} from 'react-icons/fa';
 import {useNavigate} from 'react-router';
 import styled from 'styled-components';
 import {theme} from 'styles/Theme';
 import {IChat} from 'types/chatroom.types';
-
 import {format, register} from 'timeago.js'; //임포트하기 register 한국어 선택
 import koLocale from 'timeago.js/lib/lang/ko'; //한국어 선택
 register('ko', koLocale);
@@ -57,10 +56,7 @@ const ChatRoomEl = (props: Props) => {
           </StyledChatInfo>
         </StyledInformation>
         <StyledEnterance>
-          <StyledMemberListBtn>
-            <span>참여 중인 사용자</span>
-            <StyledAngleDown></StyledAngleDown>
-          </StyledMemberListBtn>
+          <GroupChatParticipant users={props.data.users}>참여 중인 사용자</GroupChatParticipant>
           <StyledEnterButton onClick={joinHandler}>들어가기</StyledEnterButton>
         </StyledEnterance>
       </StyledInner>
@@ -128,25 +124,8 @@ const StyledLatestTime = styled.span``;
 
 const StyledEnterance = styled.div`
   display: flex;
-  gap: 0.5rem;
-`;
-
-const StyledMemberListBtn = styled.button`
-  font-size: ${theme.fonts.body1.fontSize};
-  font-weight: ${theme.fonts.body1.fontWeight};
-  line-height: ${theme.fonts.body1.lineHeight};
-
-  color: ${theme.colors.gray700};
-  display: flex;
-  gap: 0.125rem;
   align-items: center;
-  border-radius: 0.25rem;
-
-  transition: 0.5s;
-
-  &:hover {
-    background-color: ${theme.colors.blue200};
-  }
+  gap: 0.5rem;
 `;
 
 const StyledEnterButton = styled.button`
@@ -165,8 +144,4 @@ const StyledEnterButton = styled.button`
     color: ${theme.colors.blue800};
     border: 0.125rem solid ${theme.colors.blue800};
   }
-`;
-
-const StyledAngleDown = styled(FaAngleDown)`
-  color: ${theme.colors.gray600};
 `;

--- a/src/pages/GroupChatList/GroupChatRoomsLayout/GroupChatRoomsLayout.tsx
+++ b/src/pages/GroupChatList/GroupChatRoomsLayout/GroupChatRoomsLayout.tsx
@@ -1,3 +1,4 @@
+import NoSearchResult from 'components/NoSearchResult';
 import ChatRoomEl from './GroupChatRoomEl';
 import styled from 'styled-components';
 import {IChat} from 'types/chatroom.types';
@@ -10,9 +11,11 @@ interface GroupChatRoomsLayoutProps {
 const GroupChatRoomsLayout = (props: GroupChatRoomsLayoutProps) => {
   return (
     <StyledRoomContainer>
-      {props.filteredGroupChat.map(room => (
-        <ChatRoomEl key={room.id} data={room} />
-      ))}
+      {props.filteredGroupChat.length ? (
+        props.filteredGroupChat.map(room => <ChatRoomEl key={room.id} data={room} />)
+      ) : (
+        <NoSearchResult text="조건에 맞는 그룹채팅방이 없습니다" />
+      )}
     </StyledRoomContainer>
   );
 };

--- a/src/types/chatroom.types.ts
+++ b/src/types/chatroom.types.ts
@@ -9,7 +9,7 @@ export interface ChatRoom {
 export interface IChat {
   id: string;
   name: string;
-  users: User[]; // 속한 유저 id
+  users: User[];
   isPrivate: boolean;
   latestMessage: Message | null;
   updatedAt: Date;


### PR DESCRIPTION
close https://github.com/turkey-kim/8lack/issues/79
close https://github.com/turkey-kim/8lack/issues/78

## 작업내용

- 생성 모달에서 즐겨찾기된 사용자 표현
- 생성 모달에도 로딩 컴포넌트 적용
- 검색 결과 없음 컴포넌트 추가
- 그룹 채팅방 리스트 - 참여중인 사용자 보기 추가
<br>

## 주요 변경점 

- 생성 모달에서 즐겨찾기된 사용자 표현
색상과 모양은 사용자 페이지에 있는 것과 같게 맞췄습니다.

<img width="800" alt="image" src="https://github.com/turkey-kim/8lack/assets/126222848/1433aadf-f4a4-4ea5-842e-e3ed74122adb">

여담으로 JSX안에서 localStorage 조회가 되네요.. (이게 되네)
<img width="787" alt="image" src="https://github.com/turkey-kim/8lack/assets/126222848/d7bb9693-b3ad-4299-b5a3-4d0d472cbe7b">


<br>
<br>
- 생성 모달에도 로딩 시 로딩 스피너 적용
![image](https://github.com/turkey-kim/8lack/assets/126222848/b0b357a7-85f9-4567-a03f-05a6db6a8fb2)


<br>
<br>

- 검색 결과 없음 컴포넌트 생성
<img width="1102" alt="image" src="https://github.com/turkey-kim/8lack/assets/126222848/9aaf137f-f9d7-478e-b67c-6d8161f52e04">

components 폴더에 있습니다
<img width="305" alt="image" src="https://github.com/turkey-kim/8lack/assets/126222848/fb93b9a5-a333-445b-9c93-02cb6b0c5efb">

<br>
<br>

- 그룹채팅방 참여자 보기 추가
<img width="542" alt="image" src="https://github.com/turkey-kim/8lack/assets/126222848/66c59bfb-f646-4ce2-823c-4c853179887d">

<br>

## To Reviewers (optional)

- 검색결과에 관한 컴포넌트들 로딩이 지연되는 곳이나 검색결과가 없을 수 있는 곳에 적용해보면 좋을거같습니다.
