### PR TITLE
[#82] 홈페이지 추가 및 라우팅 + 네비게이션바 연동

### DIFF
--- a/src/components/Navigation/Navigation.tsx
+++ b/src/components/Navigation/Navigation.tsx
@@ -25,7 +25,7 @@ export default function Navigation() {
 
   return (
     <StyledNav>
-      <Link to="/">
+      <Link to="/home">
         <StyledLogo src={Logo} alt="Logo" />
       </Link>
       <StyledIconContainer>

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -15,6 +15,7 @@ import ChatRoom from 'pages/ChatRoom';
 import GroupChatList from './pages/GroupChatList/GroupChatList';
 import Modal from 'react-modal';
 import NonUserRoute from 'routes/NonUserRoute';
+import Home from './pages/Home';
 
 Modal.setAppElement('#root');
 const router = createBrowserRouter([
@@ -43,6 +44,10 @@ const router = createBrowserRouter([
         <SignIn />
       </NonUserRoute>
     ),
+  },
+  {
+    path: '/home',
+    element: <Home />,
   },
 ]);
 

--- a/src/pages/Home/index.tsx
+++ b/src/pages/Home/index.tsx
@@ -1,0 +1,58 @@
+import React from 'react';
+import styled from 'styled-components';
+import Navigation from 'components/Navigation/Navigation';
+import {useRecoilValue} from 'recoil';
+import {loginState} from 'states/atom';
+import {useNavigate} from 'react-router';
+import {theme} from 'styles/Theme';
+
+const Home = () => {
+  const isLoggedIn = useRecoilValue(loginState);
+  const navigate = useNavigate();
+
+  const goToSignin = () => {
+    navigate('/signin');
+  };
+
+  return (
+    <StyledContainer>
+      {isLoggedIn ? <Navigation /> : null}
+      <StyledInnerContainer>
+        {isLoggedIn ? null : <StyledSignInBtn onClick={goToSignin}>로그인</StyledSignInBtn>}
+        홈페이지
+      </StyledInnerContainer>
+    </StyledContainer>
+  );
+};
+
+export default Home;
+
+const StyledContainer = styled.div`
+  display: flex;
+  height: auto;
+`;
+
+const StyledInnerContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  overflow-y: auto;
+  padding: 4rem 2rem;
+  width: 100%;
+  height: 100vh;
+`;
+
+const StyledSignInBtn = styled.button`
+  position: absolute;
+  top: 1.5rem;
+  right: 2rem;
+  padding: 1rem 2rem;
+  border-radius: 8px;
+  background-color: ${theme.colors.blue700};
+  color: ${theme.colors.white};
+  font-weight: ${theme.fonts.subtitle1.fontWeight};
+  font-size: ${theme.fonts.subtitle5.fontSize};
+
+  &:hover {
+    background-color: ${theme.colors.blue800};
+  }
+`;

--- a/src/routes/UserPublicRoute.tsx
+++ b/src/routes/UserPublicRoute.tsx
@@ -41,7 +41,7 @@ const UserPublicRoute = ({children}: Props): any => {
 
   if (isLoading && !authorization) return <></>;
   if (!isLoading && authorization) return children;
-  if (!isLoading && !authorization) return <Navigate to="/signin" />;
+  if (!isLoading && !authorization) return <Navigate to="/home" />;
 };
 
 export default UserPublicRoute;


### PR DESCRIPTION
## 작업내용

- 홈페이지 프레임 추가

close #82 
<br>

## 주요 변경점 

-  홈패이지 추가했습니다 (경로 : src/pages/Home)

: 이제 논유저가 서비스 접속 시도할 때, 로그인페이지가 아닌 홈페이지로 이동합니다.
: 유저가 접속할 경우 네비게이션바가 보이도록 했습니다! 
: 라우팅 경로는 "/home" 입니다! 
:  src/pages/Home/components에 파일 추가 후, 맡으신 부분 구현하시면 될 것 같아요!
    => .gitkeep 파일은 삭제해주셔도 됩니다!

- 변경 전후 스크린샷 추가(권장)
<br>

## 유의할 점 (optional)

- 기능 구현하시면서 논유저 접속의 경우, 페이지의 바로가기 버튼은 로그인 페이지로 연결해주시면 될 것 같습니다!
<br>

## To Reviewers (optional)

- 확인부탁드립니다! 
