### PR TITLE
[#96] 사이드바 - 개인 채팅방 불러올 때 버벅거리는 문제 해결

### DIFF
--- a/src/components/PrivateChat/PrivateChat.tsx
+++ b/src/components/PrivateChat/PrivateChat.tsx
@@ -1,4 +1,4 @@
-import {useState, useEffect} from 'react';
+import React, {useState, useEffect} from 'react';
 import styled from 'styled-components';
 import {theme} from '../../styles/Theme';
 import {format, register} from 'timeago.js';
@@ -13,24 +13,29 @@ register('ko', koLocale);
 
 export default function PrivateChat(props: Props) {
   const [myId, setMyId] = useState<string>('');
+  const [isLoading, setIsLoading] = useState<boolean>(true);
   const {id, users} = props.data;
   const params = useParams();
   const {
-    updateQuery: {isLoading, data: realTimeData},
+    updateQuery: {data: realTimeData},
   } = useRealTimeUpdate();
 
   const selectedChatRoom = realTimeData?.chats.find((chat: IChat) => chat.id === id);
 
   const getAuth = async () => {
-    const res = await authCheck();
-    setMyId(res.user.id);
+    try {
+      const res = await authCheck();
+      setMyId(res.user.id);
+    } finally {
+      setIsLoading(false);
+    }
   };
 
   useEffect(() => {
     getAuth();
   }, []);
 
-  if (isLoading) return <p>Loading...</p>;
+  if (isLoading) return <></>;
 
   return (
     <StyledTopContainer>
@@ -57,7 +62,6 @@ export default function PrivateChat(props: Props) {
           </StyledSubContainer>
           <StyledDiv>
             <StyledDate>{format(selectedChatRoom?.updatedAt, 'ko')}</StyledDate>
-            {/* {selectedChatRoom?.latestMessage === null ? '' : <StyledLatestMessage />} */}
           </StyledDiv>
         </StyledContainer>
       </Link>

--- a/src/components/PrivateChat/PrivateChat.tsx
+++ b/src/components/PrivateChat/PrivateChat.tsx
@@ -4,7 +4,7 @@ import {theme} from '../../styles/Theme';
 import {format, register} from 'timeago.js';
 import koLocale from 'timeago.js/lib/lang/ko';
 import {Props, IChat} from 'types/chatroom.types';
-import {useNavigate, useParams} from 'react-router-dom';
+import {Link, useParams} from 'react-router-dom';
 import useRealTimeUpdate from 'hooks/useRealTimeUpdate';
 import {authCheck} from 'api/auth';
 import {USER_DEFAULT_IMG} from 'constant/constant';
@@ -14,7 +14,6 @@ register('ko', koLocale);
 export default function PrivateChat(props: Props) {
   const [myId, setMyId] = useState<string>('');
   const {id, users} = props.data;
-  const navigate = useNavigate();
   const params = useParams();
   const {
     updateQuery: {isLoading, data: realTimeData},
@@ -35,31 +34,33 @@ export default function PrivateChat(props: Props) {
 
   return (
     <StyledTopContainer>
-      <StyledContainer onClick={() => navigate(`/chat/${id}`)} className={params.chatId === id ? 'selected_chat' : ''}>
-        <StyledSubContainer>
-          {users.map(user =>
-            user.id !== myId ? (
-              <StyledImg key={user.id} src={user.picture} alt="사용자 프로필 이미지" />
-            ) : (
-              users.length === 1 && <StyledImg key={user.id} src={USER_DEFAULT_IMG} alt="알 수 없는 사용자" />
-            ),
-          )}
-          <StyledTextContainer>
+      <Link to={`/chat/${id}`}>
+        <StyledContainer className={params.chatId === id ? 'selected_chat' : ''}>
+          <StyledSubContainer>
             {users.map(user =>
               user.id !== myId ? (
-                <StyledTitle key={user.id}>{user.username}</StyledTitle>
+                <StyledImg key={user.id} src={user.picture} alt="사용자 프로필 이미지" />
               ) : (
-                users.length === 1 && <StyledTitle key={user.id}>(알 수 없음)</StyledTitle>
+                users.length === 1 && <StyledImg key={user.id} src={USER_DEFAULT_IMG} alt="알 수 없는 사용자" />
               ),
             )}
-            <StyledText>{selectedChatRoom?.latestMessage?.text}</StyledText>
-          </StyledTextContainer>
-        </StyledSubContainer>
-        <StyledDiv>
-          <StyledDate>{format(selectedChatRoom?.updatedAt, 'ko')}</StyledDate>
-          {/* {selectedChatRoom?.latestMessage === null ? '' : <StyledLatestMessage />} */}
-        </StyledDiv>
-      </StyledContainer>
+            <StyledTextContainer>
+              {users.map(user =>
+                user.id !== myId ? (
+                  <StyledTitle key={user.id}>{user.username}</StyledTitle>
+                ) : (
+                  users.length === 1 && <StyledTitle key={user.id}>(알 수 없음)</StyledTitle>
+                ),
+              )}
+              <StyledText>{selectedChatRoom?.latestMessage?.text}</StyledText>
+            </StyledTextContainer>
+          </StyledSubContainer>
+          <StyledDiv>
+            <StyledDate>{format(selectedChatRoom?.updatedAt, 'ko')}</StyledDate>
+            {/* {selectedChatRoom?.latestMessage === null ? '' : <StyledLatestMessage />} */}
+          </StyledDiv>
+        </StyledContainer>
+      </Link>
     </StyledTopContainer>
   );
 }

--- a/src/components/SideBar/SideBar.tsx
+++ b/src/components/SideBar/SideBar.tsx
@@ -21,7 +21,7 @@ export default function SideBar() {
     } finally {
       setTimeout(() => {
         setIsLoading(false);
-      }, 1500);
+      }, 1000);
     }
   };
 


### PR DESCRIPTION
## 작업내용
- 개인 채팅방 불러올 때 버벅거리는 문제 해결
- 개인 & 그룹 탭 전환시 로딩 시간 1초로 단축
<br>

## 주요 변경점 
- 버벅거리는 문제 해결
https://github.com/turkey-kim/8lack/assets/83440978/32c3db56-bf6f-4f28-b016-1956837cb2e3
<br>

## 유의할 점 (optional)
- 일단 로딩을 주어 해결하였는데 나영님이 #94 에서 남겨주신 코멘트를 토대로 훅을 사용해서 다시 해결해볼 생각입니당!
<br>

## To Reviewers (optional)
- 확인해보시고 이상있으면 코멘트 남겨주세요! 😄😄
